### PR TITLE
feat: add per-area readiness scoring, file-based instructions, and area-aware eval scaffold

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,7 @@
 # Copilot Instructions for This Repository
 
+## Development Checklist
+
 - Use ESM syntax everywhere (see "type": "module" in package.json).
 - TypeScript is strict; target ES2022, module ESNext (see tsconfig.json).
 - Use Commander for CLI, Ink/React for TUI, and simple-git/Octokit for GitHub automation.
@@ -7,6 +9,7 @@
 - All Copilot/VS Code settings reference this file and enable MCP.
 - Place new CLI commands in src/commands/, core logic in src/services/, and TUI in src/ui/.
 - Do not add new build/lint/test tools unless necessary; use existing npm scripts.
+- Ensure Windows/macOS/Linux compatibility
 
 ## Overview
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,10 @@ export function runCli(argv: string[]): void {
     .option("--repo <path>", "Repository path", process.cwd())
     .option("--output <path>", "Output path for copilot instructions")
     .option("--model <name>", "Model for instructions generation", DEFAULT_MODEL)
+    .option("--force", "Overwrite existing area instruction files")
+    .option("--areas", "Also generate file-based instructions for detected areas")
+    .option("--areas-only", "Generate only file-based area instructions (skip root)")
+    .option("--area <name>", "Generate file-based instructions for a specific area")
     .action(instructionsCommand);
 
   program
@@ -74,6 +78,7 @@ export function runCli(argv: string[]): void {
     .option("--json", "Output JSON")
     .option("--output <path>", "Write report to file (.json or .html)")
     .option("--visual", "Generate visual HTML report")
+    .option("--per-area", "Show per-area readiness breakdown")
     .action(readinessCommand);
 
   program

--- a/src/commands/instructions.tsx
+++ b/src/commands/instructions.tsx
@@ -1,13 +1,22 @@
 import fs from "fs/promises";
 import path from "path";
 
-import { generateCopilotInstructions } from "../services/instructions";
+import { analyzeRepo } from "../services/analyzer";
+import {
+  generateCopilotInstructions,
+  generateAreaInstructions,
+  writeAreaInstruction
+} from "../services/instructions";
 import { ensureDir } from "../utils/fs";
 
 type InstructionsOptions = {
   repo?: string;
   output?: string;
   model?: string;
+  force?: boolean;
+  areas?: boolean;
+  areasOnly?: boolean;
+  area?: string;
 };
 
 export async function instructionsCommand(options: InstructionsOptions): Promise<void> {
@@ -16,30 +25,100 @@ export async function instructionsCommand(options: InstructionsOptions): Promise
     options.output ?? path.join(repoPath, ".github", "copilot-instructions.md")
   );
 
-  let content = "";
-  try {
-    content = await generateCopilotInstructions({
-      repoPath,
-      model: options.model
-    });
-  } catch (error) {
-    console.error("Failed to generate instructions with Copilot SDK.");
-    console.error(
-      "Ensure the Copilot CLI is installed (copilot --version) and logged in (run 'copilot' then '/login')."
-    );
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exitCode = 1;
-    return;
-  }
-  if (!content) {
-    console.error("No instructions were generated.");
-    process.exitCode = 1;
-    return;
+  const wantAreas = options.areas || options.areasOnly || options.area;
+
+  // Generate root instructions unless --areas-only
+  if (!options.areasOnly && !options.area) {
+    let content = "";
+    try {
+      content = await generateCopilotInstructions({
+        repoPath,
+        model: options.model
+      });
+    } catch (error) {
+      console.error("Failed to generate instructions with Copilot SDK.");
+      console.error(
+        "Ensure the Copilot CLI is installed (copilot --version) and logged in (run 'copilot' then '/login')."
+      );
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+      if (!wantAreas) return;
+    }
+    if (!content && !wantAreas) {
+      console.error("No instructions were generated.");
+      process.exitCode = 1;
+      return;
+    }
+
+    if (content) {
+      await ensureDir(path.dirname(outputPath));
+      await fs.writeFile(outputPath, content, "utf8");
+      console.log(`Updated ${path.relative(process.cwd(), outputPath)}`);
+    }
   }
 
-  await ensureDir(path.dirname(outputPath));
-  await fs.writeFile(outputPath, content, "utf8");
+  // Generate area-based instructions
+  if (wantAreas) {
+    let analysis;
+    try {
+      analysis = await analyzeRepo(repoPath);
+    } catch (error) {
+      console.error(`Failed to analyze repository: ${error instanceof Error ? error.message : String(error)}`);
+      process.exitCode = 1;
+      return;
+    }
+    const areas = analysis.areas ?? [];
 
-  console.log(`Updated ${path.relative(process.cwd(), outputPath)}`);
-  console.log("Please review and share feedback on any unclear or incomplete sections.");
+    if (areas.length === 0) {
+      console.log("No areas detected. Use primer.config.json to define custom areas.");
+      return;
+    }
+
+    // Filter to specific area if --area <name> is given
+    const targetAreas = options.area
+      ? areas.filter((a) => a.name.toLowerCase() === options.area!.toLowerCase())
+      : areas;
+
+    if (options.area && targetAreas.length === 0) {
+      console.error(
+        `Area "${options.area}" not found. Available: ${areas.map((a) => a.name).join(", ")}`
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(`Generating file-based instructions for ${targetAreas.length} area(s)...`);
+
+    for (const area of targetAreas) {
+      try {
+        console.log(`  Generating for "${area.name}" (${Array.isArray(area.applyTo) ? area.applyTo.join(", ") : area.applyTo})...`);
+        const body = await generateAreaInstructions({
+          repoPath,
+          area,
+          model: options.model,
+          onProgress: (msg) => process.stdout.write(`    ${msg}\r`)
+        });
+
+        if (!body.trim()) {
+          console.log(`  Skipped "${area.name}" — no content generated.`);
+          continue;
+        }
+
+        const result = await writeAreaInstruction(repoPath, area, body, options.force);
+        if (result.status === "skipped") {
+          console.log(`  Skipped "${area.name}" — file exists (use --force to overwrite).`);
+          continue;
+        }
+        console.log(`  Wrote ${path.relative(process.cwd(), result.filePath)}`);
+      } catch (error) {
+        console.error(
+          `  Failed for "${area.name}": ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  }
+
+  if (!wantAreas) {
+    console.log("Please review and share feedback on any unclear or incomplete sections.");
+  }
 }

--- a/src/services/__tests__/visualReport.test.ts
+++ b/src/services/__tests__/visualReport.test.ts
@@ -239,4 +239,95 @@ describe("generateVisualReport", () => {
     expect(html).not.toContain('<script>alert("xss")</script>');
     expect(html).toContain("&lt;script&gt;");
   });
+
+  it("renders per-area breakdown when areaReports provided", () => {
+    const report = makeReport({
+      areaReports: [
+        {
+          area: { name: "frontend", applyTo: "frontend/**", source: "auto" },
+          criteria: [
+            {
+              id: "area-readme",
+              title: "Area README present",
+              pillar: "documentation",
+              level: 1,
+              scope: "area",
+              impact: "medium",
+              effort: "low",
+              status: "pass"
+            },
+            {
+              id: "area-build-script",
+              title: "Area build script present",
+              pillar: "build-system",
+              level: 1,
+              scope: "area",
+              impact: "high",
+              effort: "low",
+              status: "fail",
+              reason: "Missing build script in area."
+            }
+          ],
+          pillars: []
+        },
+        {
+          area: { name: "backend", applyTo: "backend/**", source: "config", description: "API layer" },
+          criteria: [
+            {
+              id: "area-readme",
+              title: "Area README present",
+              pillar: "documentation",
+              level: 1,
+              scope: "area",
+              impact: "medium",
+              effort: "low",
+              status: "pass"
+            }
+          ],
+          pillars: []
+        }
+      ]
+    });
+
+    const html = generateVisualReport({
+      reports: [{ repo: "test-repo", report }]
+    });
+
+    expect(html).toContain("Per-Area Breakdown");
+    expect(html).toContain("frontend");
+    expect(html).toContain("backend");
+    expect(html).toContain("frontend/**");
+    expect(html).toContain("backend/**");
+    expect(html).toContain("auto");
+    expect(html).toContain("config");
+    expect(html).toContain("Pass");
+    expect(html).toContain("Fail");
+  });
+
+  it("does not render area section when no areaReports", () => {
+    const html = generateVisualReport({
+      reports: [{ repo: "test-repo", report: makeReport() }]
+    });
+
+    expect(html).not.toContain("Per-Area Breakdown");
+  });
+
+  it("escapes HTML in area names", () => {
+    const report = makeReport({
+      areaReports: [
+        {
+          area: { name: '<img onerror="alert(1)">', applyTo: "x/**", source: "auto" },
+          criteria: [],
+          pillars: []
+        }
+      ]
+    });
+
+    const html = generateVisualReport({
+      reports: [{ repo: "test-repo", report }]
+    });
+
+    expect(html).not.toContain('<img onerror="alert(1)">');
+    expect(html).toContain("&lt;img");
+  });
 });

--- a/src/services/instructions.ts
+++ b/src/services/instructions.ts
@@ -1,6 +1,12 @@
+import fs from "fs/promises";
+import path from "path";
+
 import { DEFAULT_MODEL } from "../config";
 import { withCwd } from "../utils/cwd";
+import { ensureDir, fileExists } from "../utils/fs";
 
+import type { Area } from "./analyzer";
+import { sanitizeAreaName } from "./analyzer";
 import { assertCopilotCliReady } from "./copilot";
 
 type GenerateInstructionsOptions = {
@@ -91,3 +97,152 @@ Output ONLY the markdown content for the instructions file.`;
     }
   });
 }
+
+type GenerateAreaInstructionsOptions = {
+  repoPath: string;
+  area: Area;
+  model?: string;
+  onProgress?: (message: string) => void;
+};
+
+export async function generateAreaInstructions(
+  options: GenerateAreaInstructionsOptions
+): Promise<string> {
+  const { repoPath, area } = options;
+  const progress = options.onProgress ?? (() => {});
+
+  return withCwd(repoPath, async () => {
+    progress(`Checking Copilot CLI for area "${area.name}"...`);
+    const cliPath = await assertCopilotCliReady();
+
+    progress(`Starting Copilot SDK for area "${area.name}"...`);
+    const sdk = await import("@github/copilot-sdk");
+    const client = new sdk.CopilotClient({ cliPath });
+
+    try {
+      const applyToPatterns = Array.isArray(area.applyTo) ? area.applyTo : [area.applyTo];
+      const applyToStr = applyToPatterns.join(", ");
+
+      progress(`Creating session for area "${area.name}"...`);
+      const preferredModel = options.model ?? DEFAULT_MODEL;
+      const session = await client.createSession({
+        model: preferredModel,
+        streaming: true,
+        systemMessage: {
+          content: `You are an expert codebase analyst. Your task is to generate a concise .instructions.md file for a specific area of a codebase. This file will be used as a file-based custom instruction in VS Code Copilot, automatically applied when working on files matching certain patterns. Use the available tools (glob, view, grep) to explore the codebase. Output ONLY the final markdown content (no frontmatter, no explanations).`
+        },
+        infiniteSessions: { enabled: false }
+      });
+
+      let content = "";
+
+      session.on((event) => {
+        const e = event as { type: string; data?: Record<string, unknown> };
+        if (e.type === "assistant.message_delta") {
+          const delta = e.data?.deltaContent as string | undefined;
+          if (delta) {
+            content += delta;
+            progress(`Generating instructions for "${area.name}"...`);
+          }
+        } else if (e.type === "tool.execution_start") {
+          const toolName = e.data?.toolName as string | undefined;
+          progress(`${area.name}: using tool ${toolName ?? "..."}`);
+        } else if (e.type === "session.error") {
+          const errorMsg = (e.data?.message as string) ?? "Unknown error";
+          if (
+            errorMsg.toLowerCase().includes("auth") ||
+            errorMsg.toLowerCase().includes("login")
+          ) {
+            throw new Error(
+              "Copilot CLI not logged in. Run `copilot` then `/login` to authenticate."
+            );
+          }
+        }
+      });
+
+      const prompt = `Analyze the "${area.name}" area of this codebase and generate a file-based instruction file.
+
+This area covers files matching: ${applyToStr}
+${area.description ? `Description: ${area.description}` : ""}
+
+Use tools to explore ONLY the files and directories within this area:
+1. List the key files: glob for ${applyToPatterns.map((p) => `"${p}"`).join(", ")}
+2. Identify the tech stack, dependencies, and frameworks used in this area
+3. Look at key source files to understand patterns and conventions specific to this area
+
+Generate concise instructions (~10-30 lines) covering:
+- What this area does and its role in the overall project
+- Area-specific tech stack, dependencies, and frameworks
+- Coding conventions and patterns specific to this area
+- Build/test commands relevant to this area (if different from root)
+- Key files and directory structure within this area
+
+IMPORTANT:
+- Focus ONLY on this specific area, not the whole repo
+- Do NOT repeat repo-wide information (that goes in the root copilot-instructions.md)
+- Keep it complementary to root instructions
+- Output ONLY the markdown content, no YAML frontmatter, no code fences`;
+
+      progress(`Analyzing area "${area.name}"...`);
+      await session.sendAndWait({ prompt }, 180000);
+      await session.destroy();
+
+      return content.trim() || "";
+    } finally {
+      await client.stop();
+    }
+  });
+}
+
+function escapeYamlString(value: string): string {
+  return value
+    .replace(/\0/gu, "")
+    .replace(/\\/gu, "\\\\")
+    .replace(/"/gu, '\\"')
+    .replace(/\n/gu, "\\n")
+    .replace(/\r/gu, "\\r")
+    .replace(/\t/gu, "\\t");
+}
+
+export function buildAreaFrontmatter(area: Area): string {
+  const applyTo = Array.isArray(area.applyTo) ? area.applyTo : [area.applyTo];
+  const applyToValue =
+    applyTo.length === 1
+      ? `"${escapeYamlString(applyTo[0])}"`
+      : `[${applyTo.map((p) => `"${escapeYamlString(p)}"`).join(", ")}]`;
+  const desc = area.description
+    ? `Use when working on ${area.name}. ${area.description}`
+    : `Use when working on ${area.name}`;
+
+  return `---
+description: "${escapeYamlString(desc)}"
+applyTo: ${applyToValue}
+---`;
+}
+
+export function buildAreaInstructionContent(area: Area, body: string): string {
+  return `${buildAreaFrontmatter(area)}\n\n${body}\n`;
+}
+
+export function areaInstructionPath(repoPath: string, area: Area): string {
+  return path.join(repoPath, ".github", "instructions", `${sanitizeAreaName(area.name)}.instructions.md`);
+}
+
+export type WriteAreaResult = { status: "written" | "skipped" | "empty"; filePath: string };
+
+export async function writeAreaInstruction(
+  repoPath: string,
+  area: Area,
+  body: string,
+  force?: boolean
+): Promise<WriteAreaResult> {
+  const filePath = areaInstructionPath(repoPath, area);
+  if (!body.trim()) return { status: "empty", filePath };
+  if (!force && await fileExists(filePath)) return { status: "skipped", filePath };
+  await ensureDir(path.dirname(filePath));
+  await fs.writeFile(filePath, buildAreaInstructionContent(area, body), "utf8");
+  return { status: "written", filePath };
+}
+
+// Re-export for backward compatibility
+export { sanitizeAreaName } from "./analyzer";


### PR DESCRIPTION
## Summary

Adds per-area readiness scoring, file-based custom instructions for VS Code Copilot, and area-aware eval scaffold generation. This enables monorepo and multi-area projects to get granular AI readiness reports and targeted `.instructions.md` files.

### Changes across 13 files (1783 additions, 40 deletions)

**Area detection & config** (`src/services/analyzer.ts`)
- New `Area` type with `scripts`, `hasTsConfig`, `source` ("auto"/"config") fields
- Heuristic area detection from well-known directories (frontend, backend, api, etc.)
- Area detection from monorepo workspace apps
- `primer.config.json` support for custom area definitions with `applyTo` glob patterns
- Two-layer path traversal defense: pattern-level `..` rejection + `path.resolve` containment
- `sanitizeAreaName` canonical location (re-exported from `instructions.ts` for backward compat)
- Config area enrichment with `scripts` and `hasTsConfig` from discovered `package.json`/`tsconfig.json`

**Per-area readiness** (`src/services/readiness.ts`)
- `ReadinessScope` expanded: `"repo" | "app" | "area"`
- 4 area-scoped criteria: `area-readme`, `area-build-script`, `area-test-script`, `area-instructions`
- `AreaReadinessReport` type with per-area criteria results and pillar summaries
- Aggregate area results back into main criteria list with 80% pass threshold
- `--per-area` CLI flag wired through `cli.ts` → `commands/readiness.ts`
- `custom-instructions` criterion now reports file-based instruction coverage for detected areas

**File-based instructions** (`src/services/instructions.ts`, `src/commands/instructions.tsx`)
- `generateAreaInstructions()` — SDK-driven area-specific instruction generation
- `buildAreaFrontmatter()`, `buildAreaInstructionContent()`, `areaInstructionPath()`, `writeAreaInstruction()`
- YAML frontmatter with `description` and `applyTo` fields, proper escaping
- CLI flags: `--areas`, `--areas-only`, `--area <name>`, `--force`

**Visual report** (`src/services/visualReport.ts`)
- `buildAreaReportsHtml()` — collapsible per-area breakdown cards with pass/fail status
- HTML escaping on all user-controlled values (area names, applyTo patterns)

**Eval scaffold** (`src/services/evalScaffold.ts`)
- `area` field on `EvalCase` type
- Area context injected into LLM prompts for cross-area and single-area eval cases

**TUI** (`src/ui/tui.tsx`)
- Area detection on mount with area count display
- "File-based (areas)" generate option with area picker UI
- "All areas" batch generation and single-area selection with preview

**Tests** (139 tests across 7 test files, all passing)
- Area detection: heuristic dirs, monorepo apps, config override, empty dir, path traversal rejection
- Area metadata: scripts/hasTsConfig preservation from apps/heuristics/config enrichment
- Per-area readiness: pass/fail for all 4 area criteria, aggregate threshold (80% boundary), pillar reflection
- Visual report: area breakdown rendering, XSS escaping on area names
- Config loading: path traversal pattern rejection, malformed area handling

### How to test

```bash
# Run all tests
npx vitest run

# Per-area readiness report
npx tsx src/index.ts readiness . --per-area

# Generate file-based instructions for areas
npx tsx src/index.ts instructions --areas
npx tsx src/index.ts instructions --area frontend

# Visual HTML report with area breakdown
npx tsx src/index.ts readiness . --per-area --visual
```