### PR TITLE
feat: add plugin-based policy engine with shadow mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Policies can also be set in `primer.config.json` (`{ "policies": ["./my-policy.j
 
 > **Security:** Config-sourced policies are restricted to JSON files only — JS/TS module policies must be passed via `--policy`.
 
+See [docs/plugins.md](docs/plugins.md) for the full plugin authoring guide, including imperative TypeScript plugins, lifecycle hooks, and the trust model.
+
 ## Development
 
 ```bash
@@ -203,6 +205,7 @@ src/
 │   ├── evaluator.ts       # Eval runner + trajectory viewer
 │   ├── generator.ts       # MCP/VS Code config generation
 │   ├── policy.ts          # Readiness policy loading and chain resolution
+│   ├── policy/            # Plugin engine (types, compiler, loader, adapter, shadow)
 │   ├── git.ts             # Git operations (clone, branch, push)
 │   ├── github.ts          # GitHub API (Octokit)
 │   └── azureDevops.ts     # Azure DevOps API

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,202 @@
+# Primer Plugin System
+
+The unified plugin policy system allows both imperative (code) plugins and declarative (JSON) policies to run through the same engine.
+
+## Architecture
+
+```
+PolicyConfig (JSON) ──┐
+                       ├─→ compilePolicyConfig() ──→ PolicyPlugin
+Module policy (.ts) ──┘
+
+Built-in criteria ──→ buildBuiltinPlugin() ──→ PolicyPlugin
+
+PolicyPlugin[] ──→ executePlugins() ──→ EngineReport
+                                          └─→ engineReportToReadiness() ──→ ReadinessReport
+```
+
+### Pipeline Stages
+
+The engine executes plugins through 5 deterministic stages:
+
+1. **Detect** — All detectors emit signals about repository state
+2. **afterDetect** — Hooks can modify/add/remove signals via patches
+3. **beforeRecommend** — Last chance to adjust signals before recommendations
+4. **Recommend** — Recommenders emit actionable recommendations from signals
+5. **afterRecommend** — Hooks can modify/add/remove recommendations via patches
+
+After hooks complete, the engine resolves `supersedes` conflicts and computes a score.
+
+## Plugin Contract
+
+```typescript
+type PolicyPlugin = {
+  meta: PluginMeta;
+  detectors?: Detector[];
+  afterDetect?: (signals, ctx) => Promise<SignalPatch | undefined>;
+  beforeRecommend?: (signals, ctx) => Promise<SignalPatch | undefined>;
+  recommenders?: Recommender[];
+  afterRecommend?: (recs, signals, ctx) => Promise<RecommendationPatch | undefined>;
+  onError?: (error, stage, ctx) => boolean;
+};
+```
+
+### Trust Model
+
+| Trust Tier         | Source                         | Capabilities                                   |
+| ------------------ | ------------------------------ | ---------------------------------------------- |
+| `trusted-code`     | `.ts`/`.js` module or built-in | Full lifecycle hooks, arbitrary code           |
+| `safe-declarative` | `.json` policy file            | Disable, override metadata, static checks only |
+
+### Immutable Patches
+
+All hook stages return patch objects instead of mutating arrays directly:
+
+```typescript
+type SignalPatch = {
+  add?: Signal[];
+  remove?: string[]; // IDs to remove
+  modify?: Array<{ id: string; changes: Partial<Signal> }>;
+};
+```
+
+The engine applies patches and automatically records provenance (`origin.modifiedBy`).
+
+### Conflict Resolution
+
+Use `supersedes` on recommendations for explicit conflict resolution:
+
+```typescript
+const rec: Recommendation = {
+  id: "strict-lint-fix",
+  signalId: "lint-config",
+  impact: "high",
+  message: "Use stricter lint rules",
+  supersedes: ["basic-lint-fix"], // Replaces this recommendation
+  origin: { addedBy: "strict-policy" }
+};
+```
+
+Circular supersedes chains drop all involved recommendations.
+
+## Writing a Plugin
+
+There are two authoring APIs:
+
+- **`PolicyConfig`** — The high-level authoring API. You write a config object with `criteria`/`extras`/`thresholds` and the engine compiles it into a `PolicyPlugin` under the hood. This is the recommended approach for most use cases.
+- **`PolicyPlugin`** — The low-level hook-based API (shown in the Plugin Contract section above). Use this only when you need direct control over the 5-stage pipeline hooks.
+
+### Imperative Plugin (TypeScript via PolicyConfig)
+
+```typescript
+// my-policy.ts
+import type { PolicyConfig } from "primer/services/policy";
+
+const policy: PolicyConfig = {
+  name: "my-custom-policy",
+  criteria: {
+    disable: ["env-example"], // Skip this check
+    override: {
+      "lint-config": { title: "Custom Lint Title", impact: "medium" }
+    },
+    add: [
+      {
+        id: "custom-check",
+        title: "My Custom Check",
+        pillar: "code-quality",
+        level: 2,
+        scope: "repo",
+        impact: "high",
+        effort: "low",
+        check: async (ctx) => {
+          // Your check logic here
+          return { status: "pass", reason: "All good" };
+        }
+      }
+    ]
+  }
+};
+
+export default policy;
+```
+
+### Declarative Policy (JSON)
+
+```json
+{
+  "name": "strict-policy",
+  "criteria": {
+    "disable": ["env-example"],
+    "override": {
+      "lint-config": { "impact": "high" }
+    }
+  },
+  "thresholds": {
+    "passRate": 0.9
+  }
+}
+```
+
+## Using Policies
+
+### CLI
+
+```bash
+# Single policy
+primer readiness --policy ./my-policy.json
+
+# Multiple policies (comma-separated)
+primer readiness --policy ./base.json,./strict.json
+
+# npm package policy
+primer readiness --policy @org/primer-policy-strict
+```
+
+### Configuration File
+
+In `primer.config.json`:
+
+```json
+{
+  "policies": ["./policies/strict.json"]
+}
+```
+
+Config-sourced policies are restricted to JSON-only for security.
+
+## Scoring
+
+The engine computes a score from final recommendations:
+
+- Each recommendation has an `impact`: critical (5), high (4), medium (3), low (2), info (0)
+- Score = 1 - (total deductions / max possible weight)
+- Max weight = number of detected signals × 5 (signals with status "not-detected" are excluded)
+- Grades: A ≥ 0.9, B ≥ 0.8, C ≥ 0.7, D ≥ 0.6, F < 0.6
+
+## Shadow Mode
+
+> **Status: In development.** Shadow mode infrastructure (`compareShadow`, `writeShadowLog`) is implemented but not yet wired into the production readiness path. The `.primer-cache/shadow-mode.log` file is **not** written during normal `primer readiness` runs.
+
+Shadow mode is designed to validate the new plugin engine against the legacy system before switching it on by default. When wired in, it will run both paths in parallel and log discrepancies:
+
+```typescript
+import { compareShadow, writeShadowLog } from "primer/services/policy/shadow";
+
+// Compare legacy ReadinessReport against a new EngineReport
+const result = compareShadow(legacyReport, engineReport, {
+  repoPath: "/path/to/repo",
+  useNewEngine: false // Use legacy output by default
+});
+
+// Write any discrepancies to .primer-cache/shadow-mode.log
+if (result.discrepancies.length > 0) {
+  await writeShadowLog(repoPath, result.discrepancies);
+}
+```
+
+To run the plugin engine alongside the legacy path today, pass `shadow: true` to `runReadinessReport`. This populates `report.engine` with engine signals, recommendations, and score, but does not replace the legacy output:
+
+```typescript
+const report = await runReadinessReport({ repoPath, shadow: true });
+// report.engine contains: signals, recommendations, policyWarnings, score, grade
+```

--- a/src/services/__tests__/policy-adapter.test.ts
+++ b/src/services/__tests__/policy-adapter.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+
+import { engineReportToReadiness } from "../policy/adapter";
+import type { EngineReport, Signal } from "../policy/types";
+
+function makeSignal(overrides: Partial<Signal> = {}): Signal {
+  return {
+    id: "test-signal",
+    kind: "file",
+    status: "detected",
+    label: "Test Signal",
+    origin: { addedBy: "test" },
+    metadata: {
+      pillar: "documentation",
+      level: 1,
+      scope: "repo",
+      impact: "high",
+      effort: "low",
+      checkStatus: "pass"
+    },
+    ...overrides
+  };
+}
+
+function makeReport(overrides: Partial<EngineReport> = {}): EngineReport {
+  return {
+    signals: [],
+    recommendations: [],
+    policyWarnings: [],
+    score: 1,
+    grade: "A",
+    pluginChain: ["builtin"],
+    ...overrides
+  };
+}
+
+describe("engineReportToReadiness", () => {
+  it("produces a valid ReadinessReport structure", () => {
+    const result = engineReportToReadiness(makeReport(), { repoPath: "/tmp/test" });
+    expect(result.repoPath).toBe("/tmp/test");
+    expect(result.isMonorepo).toBe(false);
+    expect(result.apps).toEqual([]);
+    expect(result.generatedAt).toBeDefined();
+    expect(result.pillars).toHaveLength(9);
+    expect(result.levels).toHaveLength(5);
+    expect(result.criteria).toEqual([]);
+    expect(result.extras).toEqual([]);
+    expect(result.policies).toEqual({ chain: ["builtin"], criteriaCount: 0 });
+    expect(result.engine).toBeDefined();
+    expect(result.engine!.score).toBe(1);
+    expect(result.engine!.grade).toBe("A");
+  });
+
+  it("maps signals with pillar metadata to criteria", () => {
+    const signal = makeSignal({
+      id: "readme",
+      metadata: {
+        pillar: "documentation",
+        level: 1,
+        scope: "repo",
+        impact: "high",
+        effort: "low",
+        checkStatus: "pass"
+      }
+    });
+    const result = engineReportToReadiness(makeReport({ signals: [signal] }), {
+      repoPath: "/tmp/test"
+    });
+    expect(result.criteria).toHaveLength(1);
+    expect(result.criteria[0].id).toBe("readme");
+    expect(result.criteria[0].pillar).toBe("documentation");
+    expect(result.criteria[0].status).toBe("pass");
+    expect(result.extras).toHaveLength(0);
+  });
+
+  it("maps signals without pillar metadata to extras", () => {
+    const signal = makeSignal({
+      id: "agents-doc",
+      metadata: { checkStatus: "fail" }
+    });
+    const result = engineReportToReadiness(makeReport({ signals: [signal] }), {
+      repoPath: "/tmp/test"
+    });
+    expect(result.extras).toHaveLength(1);
+    expect(result.extras[0].id).toBe("agents-doc");
+    expect(result.extras[0].status).toBe("fail");
+    expect(result.criteria).toHaveLength(0);
+  });
+
+  it("computes pillar summaries from criteria", () => {
+    const signals = [
+      makeSignal({
+        id: "a",
+        metadata: {
+          pillar: "documentation",
+          level: 1,
+          scope: "repo",
+          impact: "high",
+          effort: "low",
+          checkStatus: "pass"
+        }
+      }),
+      makeSignal({
+        id: "b",
+        metadata: {
+          pillar: "documentation",
+          level: 1,
+          scope: "repo",
+          impact: "high",
+          effort: "low",
+          checkStatus: "fail"
+        }
+      })
+    ];
+    const result = engineReportToReadiness(makeReport({ signals }), { repoPath: "/tmp/test" });
+    const docPillar = result.pillars.find((p) => p.id === "documentation");
+    expect(docPillar).toBeDefined();
+    expect(docPillar!.passed).toBe(1);
+    expect(docPillar!.total).toBe(2);
+    expect(docPillar!.passRate).toBe(0.5);
+  });
+
+  it("computes level summaries and achievedLevel", () => {
+    const signals = [
+      makeSignal({
+        id: "c1",
+        metadata: {
+          pillar: "documentation",
+          level: 1,
+          scope: "repo",
+          impact: "high",
+          effort: "low",
+          checkStatus: "pass"
+        }
+      }),
+      makeSignal({
+        id: "c2",
+        metadata: {
+          pillar: "testing",
+          level: 1,
+          scope: "repo",
+          impact: "high",
+          effort: "low",
+          checkStatus: "pass"
+        }
+      })
+    ];
+    const result = engineReportToReadiness(makeReport({ signals }), { repoPath: "/tmp/test" });
+    expect(result.levels[0].level).toBe(1);
+    expect(result.levels[0].achieved).toBe(true);
+    expect(result.achievedLevel).toBe(1);
+    // Level 2 has no criteria → total=0 → not achieved
+    expect(result.levels[1].achieved).toBe(false);
+  });
+
+  it("skips skip-status criteria from totals", () => {
+    const signals = [
+      makeSignal({
+        id: "a",
+        metadata: {
+          pillar: "testing",
+          level: 1,
+          scope: "repo",
+          impact: "high",
+          effort: "low",
+          checkStatus: "skip"
+        }
+      })
+    ];
+    const result = engineReportToReadiness(makeReport({ signals }), { repoPath: "/tmp/test" });
+    const testPillar = result.pillars.find((p) => p.id === "testing");
+    expect(testPillar!.total).toBe(0);
+    expect(testPillar!.passRate).toBe(0);
+  });
+
+  it("respects passRateThreshold for level achievement", () => {
+    // 1 pass, 1 fail at level 1 → passRate 0.5 < default 0.8
+    const signals = [
+      makeSignal({
+        id: "a",
+        metadata: {
+          pillar: "documentation",
+          level: 1,
+          scope: "repo",
+          impact: "high",
+          effort: "low",
+          checkStatus: "pass"
+        }
+      }),
+      makeSignal({
+        id: "b",
+        metadata: {
+          pillar: "testing",
+          level: 1,
+          scope: "repo",
+          impact: "high",
+          effort: "low",
+          checkStatus: "fail"
+        }
+      })
+    ];
+    const result = engineReportToReadiness(makeReport({ signals }), {
+      repoPath: "/tmp/test",
+      passRateThreshold: 0.4
+    });
+    // With threshold at 0.4, level 1 should be achieved (passRate 0.5 >= 0.4)
+    expect(result.levels[0].achieved).toBe(true);
+    expect(result.achievedLevel).toBe(1);
+  });
+
+  it("includes policy chain metadata", () => {
+    const result = engineReportToReadiness(
+      makeReport({ pluginChain: ["builtin", "custom-policy"] }),
+      { repoPath: "/tmp/test" }
+    );
+    expect(result.policies!.chain).toEqual(["builtin", "custom-policy"]);
+  });
+
+  it("blocks level 2 achievement when level 1 fails (cascading)", () => {
+    // Level 1: 1 pass + 1 fail → passRate 0.5 < default 0.8 → not achieved
+    // Level 2: 2 passes → passRate 1.0 ≥ 0.8, but level 2 must NOT be achieved
+    // because levels are sequential: failing level N blocks N+1
+    const signals = [
+      makeSignal({
+        id: "l1a",
+        metadata: {
+          pillar: "documentation",
+          level: 1,
+          scope: "repo",
+          impact: "high",
+          effort: "low",
+          checkStatus: "pass"
+        }
+      }),
+      makeSignal({
+        id: "l1b",
+        metadata: {
+          pillar: "testing",
+          level: 1,
+          scope: "repo",
+          impact: "high",
+          effort: "low",
+          checkStatus: "fail"
+        }
+      }),
+      makeSignal({
+        id: "l2a",
+        metadata: {
+          pillar: "documentation",
+          level: 2,
+          scope: "repo",
+          impact: "high",
+          effort: "low",
+          checkStatus: "pass"
+        }
+      }),
+      makeSignal({
+        id: "l2b",
+        metadata: {
+          pillar: "testing",
+          level: 2,
+          scope: "repo",
+          impact: "high",
+          effort: "low",
+          checkStatus: "pass"
+        }
+      })
+    ];
+    const result = engineReportToReadiness(makeReport({ signals }), { repoPath: "/tmp/test" });
+    const level1 = result.levels.find((l) => l.level === 1);
+    const level2 = result.levels.find((l) => l.level === 2);
+    expect(level1!.achieved).toBe(false);
+    expect(level2!.achieved).toBe(false);
+    expect(result.achievedLevel).toBe(0);
+  });
+});

--- a/src/services/__tests__/policy-compiler.test.ts
+++ b/src/services/__tests__/policy-compiler.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it } from "vitest";
+
+import type { PolicyConfig, ExtraDefinition } from "../policy";
+import { compilePolicyConfig } from "../policy/compiler";
+import type { PolicyContext, Signal } from "../policy/types";
+import type { ReadinessCriterion } from "../readiness";
+import { buildCriteria } from "../readiness";
+
+// ─── Helpers ───
+
+function makeCtx(): PolicyContext {
+  return {
+    repoPath: "/tmp/test",
+    rootFiles: ["package.json"],
+    cache: new Map()
+  };
+}
+
+const baseCriteria = buildCriteria();
+
+// ─── compilePolicyConfig ───
+
+describe("compilePolicyConfig", () => {
+  it("compiles a minimal policy with name only", () => {
+    const config: PolicyConfig = { name: "minimal" };
+    const result = compilePolicyConfig(config, baseCriteria);
+
+    expect(result.plugin.meta.name).toBe("minimal");
+    expect(result.plugin.meta.sourceType).toBe("json");
+    expect(result.plugin.meta.trust).toBe("safe-declarative");
+    expect(result.disabledIds).toEqual([]);
+    expect(result.passRateThreshold).toBeUndefined();
+  });
+
+  it("collects disabled criterion IDs", () => {
+    const config: PolicyConfig = {
+      name: "disabler",
+      criteria: { disable: ["lint-config", "readme"] }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    expect(result.disabledIds).toEqual(["lint-config", "readme"]);
+  });
+
+  it("collects disabled extra IDs", () => {
+    const config: PolicyConfig = {
+      name: "disabler",
+      extras: { disable: ["agents-doc"] }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    expect(result.disabledIds).toContain("agents-doc");
+  });
+
+  it("combines criteria and extras disabled IDs", () => {
+    const config: PolicyConfig = {
+      name: "combined",
+      criteria: { disable: ["lint-config"] },
+      extras: { disable: ["pr-template"] }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    expect(result.disabledIds).toEqual(["lint-config", "pr-template"]);
+  });
+
+  it("extracts passRateThreshold", () => {
+    const config: PolicyConfig = {
+      name: "thresholder",
+      thresholds: { passRate: 0.9 }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    expect(result.passRateThreshold).toBe(0.9);
+  });
+
+  it("creates afterDetect hook for metadata overrides", async () => {
+    const config: PolicyConfig = {
+      name: "overrider",
+      criteria: {
+        override: {
+          "lint-config": { title: "Custom Lint Title" }
+        }
+      }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    expect(result.plugin.afterDetect).toBeDefined();
+
+    // Simulate signals and apply hook
+    const signals: Signal[] = [
+      {
+        id: "lint-config",
+        kind: "file",
+        status: "detected",
+        label: "Original",
+        origin: { addedBy: "test" }
+      }
+    ];
+    const patch = await result.plugin.afterDetect!(signals, makeCtx());
+    expect(patch).toBeDefined();
+    expect(patch!.modify).toHaveLength(1);
+    expect(patch!.modify![0].changes.label).toBe("Custom Lint Title");
+  });
+
+  it("afterDetect hook produces metadata overrides for pillar/level/impact", async () => {
+    const config: PolicyConfig = {
+      name: "meta-overrider",
+      criteria: {
+        override: {
+          "lint-config": { pillar: "testing", level: 3, impact: "high" }
+        }
+      }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    const signals: Signal[] = [
+      {
+        id: "lint-config",
+        kind: "file",
+        status: "detected",
+        label: "Lint",
+        origin: { addedBy: "test" },
+        metadata: { pillar: "style-validation", level: 1, checkStatus: "pass" }
+      }
+    ];
+    const patch = await result.plugin.afterDetect!(signals, makeCtx());
+    expect(patch).toBeDefined();
+    expect(patch!.modify).toHaveLength(1);
+    const meta = patch!.modify![0].changes.metadata as Record<string, unknown>;
+    expect(meta.pillar).toBe("testing");
+    expect(meta.level).toBe(3);
+    expect(meta.impact).toBe("high");
+  });
+
+  it("afterDetect hook skips non-existent signal IDs", async () => {
+    const config: PolicyConfig = {
+      name: "overrider",
+      criteria: {
+        override: {
+          "nonexistent-id": { title: "Nope" }
+        }
+      }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    const signals: Signal[] = [
+      {
+        id: "lint-config",
+        kind: "file",
+        status: "detected",
+        label: "Original",
+        origin: { addedBy: "test" }
+      }
+    ];
+    const patch = await result.plugin.afterDetect!(signals, makeCtx());
+    expect(patch).toBeUndefined();
+  });
+
+  it("creates detectors and recommenders from criteria.add", () => {
+    const criterion: ReadinessCriterion = {
+      id: "custom-check",
+      title: "Custom Check",
+      pillar: "code-quality",
+      level: 1,
+      scope: "repo",
+      impact: "medium",
+      effort: "low",
+      check: async () => ({ status: "pass" })
+    };
+    const config: PolicyConfig = {
+      name: "adder",
+      criteria: { add: [criterion] }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    expect(result.plugin.detectors).toHaveLength(1);
+    expect(result.plugin.detectors![0].id).toBe("custom-check");
+    expect(result.plugin.recommenders).toHaveLength(1);
+    expect(result.plugin.recommenders![0].id).toBe("custom-check-rec");
+  });
+
+  it("compiled detector emits a signal from a passing criterion", async () => {
+    const criterion: ReadinessCriterion = {
+      id: "my-criterion",
+      title: "My Title",
+      pillar: "documentation",
+      level: 1,
+      scope: "repo",
+      impact: "high",
+      effort: "low",
+      check: async () => ({ status: "pass", reason: "All good" })
+    };
+    const config: PolicyConfig = {
+      name: "checker",
+      criteria: { add: [criterion] }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    const signal = await result.plugin.detectors![0].detect(makeCtx());
+    const s = Array.isArray(signal) ? signal[0] : signal;
+    expect(s.id).toBe("my-criterion");
+    expect(s.label).toBe("My Title");
+    expect(s.origin.addedBy).toBe("compiled:my-criterion");
+    expect(s.metadata).toHaveProperty("checkStatus", "pass");
+  });
+
+  it("compiled recommender emits recommendation for failing criterion", async () => {
+    const signals: Signal[] = [
+      {
+        id: "my-criterion",
+        kind: "file",
+        status: "detected",
+        label: "My Title",
+        reason: "Something failed",
+        origin: { addedBy: "compiled:my-criterion" },
+        metadata: { checkStatus: "fail" }
+      }
+    ];
+    const criterion: ReadinessCriterion = {
+      id: "my-criterion",
+      title: "My Title",
+      pillar: "documentation",
+      level: 1,
+      scope: "repo",
+      impact: "high",
+      effort: "low",
+      check: async () => ({ status: "fail", reason: "Something failed" })
+    };
+    const config: PolicyConfig = {
+      name: "checker",
+      criteria: { add: [criterion] }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    const rec = await result.plugin.recommenders![0].recommend(signals, makeCtx());
+    const r = Array.isArray(rec) ? rec[0] : rec;
+    expect(r.id).toBe("my-criterion-fix");
+    expect(r.impact).toBe("high");
+  });
+
+  it("compiled recommender uses runtime impact from signal.metadata (afterDetect override)", async () => {
+    // Simulate an afterDetect hook that overrides impact to "medium" in signal metadata
+    const signals: Signal[] = [
+      {
+        id: "my-criterion",
+        kind: "file",
+        status: "detected",
+        label: "My Title",
+        reason: "Something failed",
+        origin: { addedBy: "compiled:my-criterion" },
+        // afterDetect has patched impact to "medium" (down from original "high")
+        metadata: { checkStatus: "fail", impact: "medium" }
+      }
+    ];
+    const criterion: ReadinessCriterion = {
+      id: "my-criterion",
+      title: "My Title",
+      pillar: "documentation",
+      level: 1,
+      scope: "repo",
+      impact: "high", // original compile-time impact
+      effort: "low",
+      check: async () => ({ status: "fail" })
+    };
+    const config: PolicyConfig = {
+      name: "checker",
+      criteria: { add: [criterion] }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    const rec = await result.plugin.recommenders![0].recommend(signals, makeCtx());
+    const r = Array.isArray(rec) ? rec[0] : rec;
+    // Must use runtime impact "medium", not compile-time "high"
+    expect(r.impact).toBe("medium");
+  });
+
+  it("compiled recommender returns empty for passing criterion", async () => {
+    const signals: Signal[] = [
+      {
+        id: "my-criterion",
+        kind: "file",
+        status: "detected",
+        label: "My Title",
+        origin: { addedBy: "compiled:my-criterion" },
+        metadata: { checkStatus: "pass" }
+      }
+    ];
+    const criterion: ReadinessCriterion = {
+      id: "my-criterion",
+      title: "My Title",
+      pillar: "documentation",
+      level: 1,
+      scope: "repo",
+      impact: "high",
+      effort: "low",
+      check: async () => ({ status: "pass" })
+    };
+    const config: PolicyConfig = {
+      name: "checker",
+      criteria: { add: [criterion] }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    const rec = await result.plugin.recommenders![0].recommend(signals, makeCtx());
+    const recs = Array.isArray(rec) ? rec : [rec];
+    expect(recs).toHaveLength(0);
+  });
+
+  it("has no detectors/recommenders/hooks when policy only disables", () => {
+    const config: PolicyConfig = {
+      name: "disabler-only",
+      criteria: { disable: ["lint-config"] }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    expect(result.plugin.detectors).toBeUndefined();
+    expect(result.plugin.recommenders).toBeUndefined();
+    expect(result.plugin.afterDetect).toBeUndefined();
+  });
+
+  it("creates detectors and recommenders from extras.add", () => {
+    const extra: ExtraDefinition = {
+      id: "custom-extra",
+      title: "Custom Extra",
+      check: async () => ({ status: "pass", reason: "OK" })
+    };
+    const config: PolicyConfig = {
+      name: "extra-adder",
+      extras: { add: [extra] }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    expect(result.plugin.detectors).toHaveLength(1);
+    expect(result.plugin.detectors![0].id).toBe("custom-extra");
+    expect(result.plugin.detectors![0].kind).toBe("custom");
+    expect(result.plugin.recommenders).toHaveLength(1);
+    expect(result.plugin.recommenders![0].id).toBe("custom-extra-rec");
+  });
+
+  it("compiled extra recommender emits low-impact recommendation on fail", async () => {
+    const signals: Signal[] = [
+      {
+        id: "custom-extra",
+        kind: "custom",
+        status: "detected",
+        label: "Custom Extra",
+        reason: "Missing thing",
+        origin: { addedBy: "compiled:custom-extra" },
+        metadata: { checkStatus: "fail" }
+      }
+    ];
+    const extra: ExtraDefinition = {
+      id: "custom-extra",
+      title: "Custom Extra",
+      check: async () => ({ status: "fail", reason: "Missing thing" })
+    };
+    const config: PolicyConfig = {
+      name: "extra-adder",
+      extras: { add: [extra] }
+    };
+    const result = compilePolicyConfig(config, baseCriteria);
+    const rec = await result.plugin.recommenders![0].recommend(signals, makeCtx());
+    const r = Array.isArray(rec) ? rec[0] : rec;
+    expect(r.id).toBe("custom-extra-fix");
+    expect(r.impact).toBe("low");
+  });
+});

--- a/src/services/__tests__/policy-engine-types.test.ts
+++ b/src/services/__tests__/policy-engine-types.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, it } from "vitest";
+
+import type { Signal, Recommendation, SignalPatch, RecommendationPatch } from "../policy/types";
+import {
+  calculateScore,
+  applySignalPatch,
+  applyRecommendationPatch,
+  resolveSupersedes
+} from "../policy/types";
+
+// ─── Helpers ───
+
+function makeSignal(overrides: Partial<Signal> & { id: string }): Signal {
+  return {
+    kind: "file",
+    status: "detected",
+    label: overrides.id,
+    origin: { addedBy: "test-plugin" },
+    ...overrides
+  };
+}
+
+function makeRec(
+  overrides: Partial<Recommendation> & { id: string; signalId: string }
+): Recommendation {
+  return {
+    impact: "medium",
+    message: `Fix ${overrides.id}`,
+    origin: { addedBy: "test-plugin" },
+    ...overrides
+  };
+}
+
+// ─── calculateScore ───
+
+describe("calculateScore", () => {
+  it("returns perfect score when no recommendations exist", () => {
+    const signals = [makeSignal({ id: "s1" })];
+    const { score, grade } = calculateScore(signals, []);
+    expect(score).toBe(1);
+    expect(grade).toBe("A");
+  });
+
+  it("returns perfect score when signals array is empty", () => {
+    const { score, grade } = calculateScore([], []);
+    expect(score).toBe(1);
+    expect(grade).toBe("A");
+  });
+
+  it("deducts score based on recommendation impact weights", () => {
+    const signals = [makeSignal({ id: "s1" }), makeSignal({ id: "s2" })];
+    // maxWeight = 2 * 5 (critical) = 10
+    // one medium rec = weight 3, deduction = 3/10 = 0.3, score = 0.7
+    const recs = [makeRec({ id: "r1", signalId: "s1", impact: "medium" })];
+    const { score } = calculateScore(signals, recs);
+    expect(score).toBeCloseTo(0.7, 3);
+  });
+
+  it("returns grade F for high deductions", () => {
+    const signals = [makeSignal({ id: "s1" })];
+    // maxWeight = 1 * 5 = 5, critical = 5, deduction = 5/5 = 1 → score = 0
+    const recs = [makeRec({ id: "r1", signalId: "s1", impact: "critical" })];
+    const { score, grade } = calculateScore(signals, recs);
+    expect(score).toBe(0);
+    expect(grade).toBe("F");
+  });
+
+  it("info impact does not affect score", () => {
+    const signals = [makeSignal({ id: "s1" })];
+    const recs = [makeRec({ id: "r1", signalId: "s1", impact: "info" })];
+    const { score } = calculateScore(signals, recs);
+    expect(score).toBe(1);
+  });
+
+  it("assigns grade B for score 0.8-0.89", () => {
+    const signals = [
+      makeSignal({ id: "s1" }),
+      makeSignal({ id: "s2" }),
+      makeSignal({ id: "s3" }),
+      makeSignal({ id: "s4" }),
+      makeSignal({ id: "s5" })
+    ];
+    // maxWeight = 5 * 5 = 25
+    // one high rec = 4, score = 1 - 4/25 = 0.84 → B
+    const recs = [makeRec({ id: "r1", signalId: "s1", impact: "high" })];
+    const { grade } = calculateScore(signals, recs);
+    expect(grade).toBe("B");
+  });
+
+  it("assigns grade C for score 0.7-0.79", () => {
+    // 5 signals, maxWeight = 25, two medium recs = 6, score = 1 - 6/25 = 0.76 → C
+    const signals = [
+      makeSignal({ id: "s1" }),
+      makeSignal({ id: "s2" }),
+      makeSignal({ id: "s3" }),
+      makeSignal({ id: "s4" }),
+      makeSignal({ id: "s5" })
+    ];
+    const recs = [
+      makeRec({ id: "r1", signalId: "s1", impact: "medium" }),
+      makeRec({ id: "r2", signalId: "s2", impact: "medium" })
+    ];
+    const { grade } = calculateScore(signals, recs);
+    expect(grade).toBe("C");
+  });
+
+  it("assigns grade D for score 0.6-0.69", () => {
+    const signals = [
+      makeSignal({ id: "s1" }),
+      makeSignal({ id: "s2" }),
+      makeSignal({ id: "s3" }),
+      makeSignal({ id: "s4" }),
+      makeSignal({ id: "s5" })
+    ];
+    // maxWeight = 5 * 5 = 25, two high recs = 8, score = 1 - 8/25 = 0.68 → D
+    const recs = [
+      makeRec({ id: "r1", signalId: "s1", impact: "high" }),
+      makeRec({ id: "r2", signalId: "s2", impact: "high" })
+    ];
+    const { grade } = calculateScore(signals, recs);
+    expect(grade).toBe("D");
+  });
+  it("clamps score to 0 when deductions exceed maxWeight", () => {
+    const signals = [makeSignal({ id: "s1" })];
+    // maxWeight = 1 * 5 = 5, two critical recs = 10, clamped to 0
+    const recs = [
+      makeRec({ id: "r1", signalId: "s1", impact: "critical" }),
+      makeRec({ id: "r2", signalId: "s1", impact: "critical" })
+    ];
+    const { score, grade } = calculateScore(signals, recs);
+    expect(score).toBe(0);
+    expect(grade).toBe("F");
+  });
+
+  it("excludes not-detected signals from score denominator", () => {
+    // 3 signals: 2 detected, 1 not-detected (skipped)
+    // maxWeight should be 2 * 5 = 10, NOT 3 * 5 = 15
+    const signals = [
+      makeSignal({ id: "s1", status: "detected" }),
+      makeSignal({ id: "s2", status: "detected" }),
+      makeSignal({ id: "s3", status: "not-detected" })
+    ];
+    const recs = [makeRec({ id: "r1", signalId: "s1", impact: "medium" })];
+    // deductions = 3 (medium), maxWeight = 2 * 5 = 10, score = 1 - 3/10 = 0.7
+    const { score } = calculateScore(signals, recs);
+    expect(score).toBeCloseTo(0.7, 3);
+  });
+
+  it("returns perfect score when all signals are not-detected", () => {
+    const signals = [
+      makeSignal({ id: "s1", status: "not-detected" }),
+      makeSignal({ id: "s2", status: "not-detected" })
+    ];
+    const { score, grade } = calculateScore(signals, []);
+    expect(score).toBe(1);
+    expect(grade).toBe("A");
+  });
+});
+
+// ─── applySignalPatch ───
+
+describe("applySignalPatch", () => {
+  it("adds new signals", () => {
+    const signals = [makeSignal({ id: "s1" })];
+    const patch: SignalPatch = {
+      add: [makeSignal({ id: "s2", origin: { addedBy: "hook-plugin" } })]
+    };
+    const result = applySignalPatch(signals, patch, "hook-plugin");
+    expect(result).toHaveLength(2);
+    expect(result[1].id).toBe("s2");
+  });
+
+  it("removes signals by id", () => {
+    const signals = [makeSignal({ id: "s1" }), makeSignal({ id: "s2" })];
+    const patch: SignalPatch = { remove: ["s1"] };
+    const result = applySignalPatch(signals, patch, "hook-plugin");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("s2");
+  });
+
+  it("modifies signals and records provenance", () => {
+    const signals = [makeSignal({ id: "s1", status: "detected" })];
+    const patch: SignalPatch = {
+      modify: [{ id: "s1", changes: { status: "not-detected" } }]
+    };
+    const result = applySignalPatch(signals, patch, "hook-plugin");
+    expect(result[0].status).toBe("not-detected");
+    expect(result[0].origin.modifiedBy).toEqual(["hook-plugin"]);
+  });
+
+  it("accumulates multiple modifiers in provenance", () => {
+    const signals = [
+      makeSignal({
+        id: "s1",
+        origin: { addedBy: "original", modifiedBy: ["first-mod"] }
+      })
+    ];
+    const patch: SignalPatch = {
+      modify: [{ id: "s1", changes: { label: "Updated" } }]
+    };
+    const result = applySignalPatch(signals, patch, "second-mod");
+    expect(result[0].origin.modifiedBy).toEqual(["first-mod", "second-mod"]);
+  });
+
+  it("does not mutate the original array", () => {
+    const original = makeSignal({ id: "s1" });
+    const signals = [original];
+    const patch: SignalPatch = { remove: ["s1"] };
+    applySignalPatch(signals, patch, "hook");
+    expect(signals).toHaveLength(1); // original unchanged
+  });
+
+  it("ignores modify for non-existent signal id", () => {
+    const signals = [makeSignal({ id: "s1" })];
+    const patch: SignalPatch = {
+      modify: [{ id: "nonexistent", changes: { label: "Nope" } }]
+    };
+    const result = applySignalPatch(signals, patch, "hook");
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe("s1");
+  });
+
+  it("applies remove, modify, add in correct order", () => {
+    const signals = [makeSignal({ id: "s1" }), makeSignal({ id: "s2" })];
+    const patch: SignalPatch = {
+      remove: ["s1"],
+      modify: [{ id: "s2", changes: { label: "Modified" } }],
+      add: [makeSignal({ id: "s3", origin: { addedBy: "hook" } })]
+    };
+    const result = applySignalPatch(signals, patch, "hook");
+    expect(result.map((s) => s.id)).toEqual(["s2", "s3"]);
+    expect(result[0].label).toBe("Modified");
+  });
+
+  it("handles empty patch as a no-op", () => {
+    const signals = [makeSignal({ id: "s1" })];
+    const result = applySignalPatch(signals, {}, "hook");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("s1");
+  });
+
+  it("deep-clones evidence and metadata in add", () => {
+    const evidence = ["file.ts"];
+    const metadata = { key: "value" };
+    const patch: SignalPatch = {
+      add: [makeSignal({ id: "s2", evidence, metadata, origin: { addedBy: "hook" } })]
+    };
+    const result = applySignalPatch([], patch, "hook");
+    // Mutating original should not affect result
+    evidence.push("other.ts");
+    metadata.key = "mutated";
+    expect(result[0].evidence).toEqual(["file.ts"]);
+    expect(result[0].metadata).toEqual({ key: "value" });
+  });
+
+  it("deep-merges metadata on modify instead of replacing", () => {
+    const signals = [
+      makeSignal({
+        id: "s1",
+        metadata: { pillar: "docs", level: 1, checkStatus: "pass" }
+      })
+    ];
+    const patch: SignalPatch = {
+      modify: [{ id: "s1", changes: { metadata: { pillar: "testing" } } }]
+    };
+    const result = applySignalPatch(signals, patch, "hook");
+    // pillar is overridden, but checkStatus and level are preserved
+    expect(result[0].metadata).toEqual({ pillar: "testing", level: 1, checkStatus: "pass" });
+  });
+});
+
+// ─── applyRecommendationPatch ───
+
+describe("applyRecommendationPatch", () => {
+  it("adds new recommendations", () => {
+    const recs = [makeRec({ id: "r1", signalId: "s1" })];
+    const patch: RecommendationPatch = {
+      add: [makeRec({ id: "r2", signalId: "s2", origin: { addedBy: "hook" } })]
+    };
+    const result = applyRecommendationPatch(recs, patch, "hook");
+    expect(result).toHaveLength(2);
+  });
+
+  it("removes recommendations by id", () => {
+    const recs = [makeRec({ id: "r1", signalId: "s1" }), makeRec({ id: "r2", signalId: "s2" })];
+    const patch: RecommendationPatch = { remove: ["r1"] };
+    const result = applyRecommendationPatch(recs, patch, "hook");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r2");
+  });
+
+  it("modifies recommendations and records provenance", () => {
+    const recs = [makeRec({ id: "r1", signalId: "s1", impact: "low" })];
+    const patch: RecommendationPatch = {
+      modify: [{ id: "r1", changes: { impact: "critical" } }]
+    };
+    const result = applyRecommendationPatch(recs, patch, "escalator");
+    expect(result[0].impact).toBe("critical");
+    expect(result[0].origin.modifiedBy).toEqual(["escalator"]);
+  });
+
+  it("does not mutate the original array", () => {
+    const original = makeRec({ id: "r1", signalId: "s1" });
+    const recs = [original];
+    const patch: RecommendationPatch = { remove: ["r1"] };
+    applyRecommendationPatch(recs, patch, "hook");
+    expect(recs).toHaveLength(1);
+  });
+
+  it("ignores modify for non-existent recommendation id", () => {
+    const recs = [makeRec({ id: "r1", signalId: "s1" })];
+    const patch: RecommendationPatch = {
+      modify: [{ id: "nonexistent", changes: { message: "Nope" } }]
+    };
+    const result = applyRecommendationPatch(recs, patch, "hook");
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe("Fix r1");
+  });
+
+  it("accumulates multiple modifiers in provenance", () => {
+    const recs = [
+      makeRec({
+        id: "r1",
+        signalId: "s1",
+        origin: { addedBy: "original", modifiedBy: ["first-mod"] }
+      })
+    ];
+    const patch: RecommendationPatch = {
+      modify: [{ id: "r1", changes: { message: "Updated" } }]
+    };
+    const result = applyRecommendationPatch(recs, patch, "second-mod");
+    expect(result[0].origin.modifiedBy).toEqual(["first-mod", "second-mod"]);
+  });
+
+  it("applies remove, modify, add in correct order", () => {
+    const recs = [makeRec({ id: "r1", signalId: "s1" }), makeRec({ id: "r2", signalId: "s2" })];
+    const patch: RecommendationPatch = {
+      remove: ["r1"],
+      modify: [{ id: "r2", changes: { message: "Modified" } }],
+      add: [makeRec({ id: "r3", signalId: "s3", origin: { addedBy: "hook" } })]
+    };
+    const result = applyRecommendationPatch(recs, patch, "hook");
+    expect(result.map((r) => r.id)).toEqual(["r2", "r3"]);
+    expect(result[0].message).toBe("Modified");
+  });
+});
+
+// ─── resolveSupersedes ───
+
+describe("resolveSupersedes", () => {
+  it("removes recommendations that are superseded", () => {
+    const recs = [
+      makeRec({ id: "r1", signalId: "s1" }),
+      makeRec({ id: "r2", signalId: "s1", supersedes: ["r1"] })
+    ];
+    const result = resolveSupersedes(recs);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r2");
+  });
+
+  it("keeps all recommendations when none are superseded", () => {
+    const recs = [makeRec({ id: "r1", signalId: "s1" }), makeRec({ id: "r2", signalId: "s2" })];
+    const result = resolveSupersedes(recs);
+    expect(result).toHaveLength(2);
+  });
+
+  it("handles transitive supersedes", () => {
+    const recs = [
+      makeRec({ id: "r1", signalId: "s1" }),
+      makeRec({ id: "r2", signalId: "s1", supersedes: ["r1"] }),
+      makeRec({ id: "r3", signalId: "s1", supersedes: ["r2"] })
+    ];
+    const result = resolveSupersedes(recs);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r3");
+  });
+
+  it("handles multiple supersedes in one recommendation", () => {
+    const recs = [
+      makeRec({ id: "r1", signalId: "s1" }),
+      makeRec({ id: "r2", signalId: "s2" }),
+      makeRec({ id: "r3", signalId: "s1", supersedes: ["r1", "r2"] })
+    ];
+    const result = resolveSupersedes(recs);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r3");
+  });
+
+  it("drops both recommendations in circular supersedes", () => {
+    const recs = [
+      makeRec({ id: "r1", signalId: "s1", supersedes: ["r2"] }),
+      makeRec({ id: "r2", signalId: "s1", supersedes: ["r1"] })
+    ];
+    const result = resolveSupersedes(recs);
+    expect(result).toHaveLength(0);
+  });
+
+  it("records provenance on the superseding recommendation", () => {
+    const recs = [
+      makeRec({ id: "r1", signalId: "s1" }),
+      makeRec({ id: "r2", signalId: "s1", supersedes: ["r1"] })
+    ];
+    const result = resolveSupersedes(recs);
+    expect(result[0].origin.modifiedBy).toEqual(["superseded:r1"]);
+  });
+
+  it("ignores supersedes references to non-existent IDs", () => {
+    const recs = [makeRec({ id: "r1", signalId: "s1", supersedes: ["nonexistent"] })];
+    const result = resolveSupersedes(recs);
+    expect(result).toHaveLength(1);
+    expect(result[0].origin.modifiedBy).toBeUndefined();
+  });
+});

--- a/src/services/__tests__/policy-engine.test.ts
+++ b/src/services/__tests__/policy-engine.test.ts
@@ -1,0 +1,607 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { executePlugins } from "../policy/engine";
+import type {
+  PolicyPlugin,
+  PolicyContext,
+  Signal,
+  Recommendation,
+  Detector,
+  Recommender
+} from "../policy/types";
+
+// ─── Helpers ───
+
+function makeCtx(overrides?: Partial<PolicyContext>): PolicyContext {
+  return {
+    repoPath: "/tmp/test-repo",
+    rootFiles: ["README.md", "package.json"],
+    cache: new Map(),
+    ...overrides
+  };
+}
+
+function makeDetector(id: string, result: Signal | Signal[]): Detector {
+  return {
+    id,
+    kind: "file",
+    detect: vi.fn().mockResolvedValue(result)
+  };
+}
+
+function makeRecommender(id: string, result: Recommendation | Recommendation[]): Recommender {
+  return {
+    id,
+    recommend: vi.fn().mockResolvedValue(result)
+  };
+}
+
+function makePlugin(
+  overrides: Partial<PolicyPlugin> & { meta: PolicyPlugin["meta"] }
+): PolicyPlugin {
+  return { ...overrides };
+}
+
+const META = {
+  name: "test-plugin",
+  sourceType: "builtin" as const,
+  trust: "trusted-code" as const
+};
+
+// ─── executePlugins ───
+
+describe("executePlugins", () => {
+  it("runs detectors and recommenders through the full pipeline", async () => {
+    const signal: Signal = {
+      id: "readme-missing",
+      kind: "file",
+      status: "detected",
+      label: "README missing",
+      origin: { addedBy: "test-plugin" }
+    };
+    const rec: Recommendation = {
+      id: "add-readme",
+      signalId: "readme-missing",
+      impact: "high",
+      message: "Add a README.md",
+      origin: { addedBy: "test-plugin" }
+    };
+
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [makeDetector("readme-check", signal)],
+      recommenders: [makeRecommender("readme-rec", rec)]
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+
+    expect(report.signals).toHaveLength(1);
+    expect(report.signals[0].id).toBe("readme-missing");
+    expect(report.recommendations).toHaveLength(1);
+    expect(report.recommendations[0].id).toBe("add-readme");
+    expect(report.pluginChain).toEqual(["test-plugin"]);
+    expect(report.score).toBeLessThan(1);
+  });
+
+  it("executes multiple plugins in source order", async () => {
+    const order: string[] = [];
+
+    const plugin1 = makePlugin({
+      meta: { ...META, name: "plugin-1" },
+      detectors: [
+        {
+          id: "d1",
+          kind: "file",
+          detect: async () => {
+            order.push("detect-1");
+            return {
+              id: "s1",
+              kind: "file",
+              status: "detected",
+              label: "S1",
+              origin: { addedBy: "plugin-1" }
+            };
+          }
+        }
+      ]
+    });
+
+    const plugin2 = makePlugin({
+      meta: { ...META, name: "plugin-2" },
+      detectors: [
+        {
+          id: "d2",
+          kind: "file",
+          detect: async () => {
+            order.push("detect-2");
+            return {
+              id: "s2",
+              kind: "file",
+              status: "detected",
+              label: "S2",
+              origin: { addedBy: "plugin-2" }
+            };
+          }
+        }
+      ]
+    });
+
+    await executePlugins([plugin1, plugin2], makeCtx());
+    expect(order).toEqual(["detect-1", "detect-2"]);
+  });
+
+  it("applies afterDetect hook patches", async () => {
+    const signal: Signal = {
+      id: "s1",
+      kind: "file",
+      status: "detected",
+      label: "Original",
+      origin: { addedBy: "base" }
+    };
+
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [makeDetector("d1", signal)],
+      afterDetect: async () => ({
+        modify: [{ id: "s1", changes: { label: "Patched" } }]
+      }),
+      recommenders: [
+        {
+          id: "r1",
+          recommend: async (signals) => {
+            // Verify recommender sees the patched signal
+            expect(signals[0].label).toBe("Patched");
+            return [];
+          }
+        }
+      ]
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.signals[0].label).toBe("Patched");
+    expect(report.signals[0].origin.modifiedBy).toEqual(["test-plugin"]);
+  });
+
+  it("applies afterRecommend hook patches", async () => {
+    const signal: Signal = {
+      id: "s1",
+      kind: "file",
+      status: "detected",
+      label: "S1",
+      origin: { addedBy: "base" }
+    };
+    const rec: Recommendation = {
+      id: "r1",
+      signalId: "s1",
+      impact: "low",
+      message: "Original",
+      origin: { addedBy: "base" }
+    };
+
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [makeDetector("d1", signal)],
+      recommenders: [makeRecommender("rec1", rec)],
+      afterRecommend: async () => ({
+        modify: [{ id: "r1", changes: { impact: "critical" } }]
+      })
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.recommendations[0].impact).toBe("critical");
+  });
+
+  it("skips disabled rule IDs for detectors and recommenders", async () => {
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [
+        makeDetector("enabled-d", {
+          id: "s1",
+          kind: "file",
+          status: "detected",
+          label: "S1",
+          origin: { addedBy: "test" }
+        }),
+        makeDetector("disabled-d", {
+          id: "s2",
+          kind: "file",
+          status: "detected",
+          label: "S2",
+          origin: { addedBy: "test" }
+        })
+      ],
+      recommenders: [
+        makeRecommender("enabled-r", {
+          id: "r1",
+          signalId: "s1",
+          impact: "medium",
+          message: "R1",
+          origin: { addedBy: "test" }
+        }),
+        makeRecommender("disabled-r", {
+          id: "r2",
+          signalId: "s2",
+          impact: "medium",
+          message: "R2",
+          origin: { addedBy: "test" }
+        })
+      ]
+    });
+
+    const report = await executePlugins([plugin], makeCtx(), {
+      disabledRuleIds: new Set(["disabled-d", "disabled-r"])
+    });
+
+    expect(report.signals).toHaveLength(1);
+    expect(report.signals[0].id).toBe("s1");
+    expect(report.recommendations).toHaveLength(1);
+    expect(report.recommendations[0].id).toBe("r1");
+  });
+
+  it("resolves supersedes in final output", async () => {
+    const signal: Signal = {
+      id: "s1",
+      kind: "file",
+      status: "detected",
+      label: "S1",
+      origin: { addedBy: "test" }
+    };
+    const recs: Recommendation[] = [
+      { id: "r1", signalId: "s1", impact: "low", message: "Base", origin: { addedBy: "base" } },
+      {
+        id: "r2",
+        signalId: "s1",
+        impact: "high",
+        message: "Override",
+        origin: { addedBy: "override" },
+        supersedes: ["r1"]
+      }
+    ];
+
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [makeDetector("d1", signal)],
+      recommenders: [makeRecommender("rec1", recs)]
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.recommendations).toHaveLength(1);
+    expect(report.recommendations[0].id).toBe("r2");
+  });
+
+  it("records warnings for caught errors and continues", async () => {
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [
+        {
+          id: "failing",
+          kind: "file",
+          detect: async () => {
+            throw new Error("disk read failed");
+          }
+        }
+      ],
+      onError: () => true // continue on error
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.policyWarnings).toHaveLength(1);
+    expect(report.policyWarnings[0].pluginName).toBe("test-plugin");
+    expect(report.policyWarnings[0].stage).toBe("detect");
+    expect(report.policyWarnings[0].message).toBe("disk read failed");
+  });
+
+  it("returns empty report for no plugins", async () => {
+    const report = await executePlugins([], makeCtx());
+    expect(report.signals).toEqual([]);
+    expect(report.recommendations).toEqual([]);
+    expect(report.score).toBe(1);
+    expect(report.grade).toBe("A");
+    expect(report.pluginChain).toEqual([]);
+  });
+
+  it("shares the same context cache across plugins", async () => {
+    const plugin1 = makePlugin({
+      meta: { ...META, name: "writer" },
+      detectors: [
+        {
+          id: "d1",
+          kind: "custom",
+          detect: async (ctx) => {
+            ctx.cache.set("shared-key", 42);
+            return {
+              id: "s1",
+              kind: "custom",
+              status: "detected",
+              label: "S1",
+              origin: { addedBy: "writer" }
+            };
+          }
+        }
+      ]
+    });
+
+    const plugin2 = makePlugin({
+      meta: { ...META, name: "reader" },
+      detectors: [
+        {
+          id: "d2",
+          kind: "custom",
+          detect: async (ctx) => {
+            const val = ctx.cache.get("shared-key");
+            return {
+              id: "s2",
+              kind: "custom",
+              status: val === 42 ? "detected" : "error",
+              label: "S2",
+              origin: { addedBy: "reader" }
+            };
+          }
+        }
+      ]
+    });
+
+    const report = await executePlugins([plugin1, plugin2], makeCtx());
+    expect(report.signals[1].status).toBe("detected");
+  });
+
+  it("produces deterministic output for identical inputs", async () => {
+    const signal: Signal = {
+      id: "s1",
+      kind: "file",
+      status: "detected",
+      label: "S1",
+      origin: { addedBy: "test" }
+    };
+    const rec: Recommendation = {
+      id: "r1",
+      signalId: "s1",
+      impact: "medium",
+      message: "Fix it",
+      origin: { addedBy: "test" }
+    };
+
+    const makeRun = () => {
+      const plugin = makePlugin({
+        meta: META,
+        detectors: [makeDetector("d1", signal)],
+        recommenders: [makeRecommender("rec1", rec)]
+      });
+      return executePlugins([plugin], makeCtx());
+    };
+
+    const [report1, report2] = await Promise.all([makeRun(), makeRun()]);
+    expect(report1.signals).toEqual(report2.signals);
+    expect(report1.recommendations).toEqual(report2.recommendations);
+    expect(report1.score).toBe(report2.score);
+    expect(report1.grade).toBe(report2.grade);
+  });
+
+  it("applies beforeRecommend hook patches visible to recommenders", async () => {
+    const signal: Signal = {
+      id: "s1",
+      kind: "file",
+      status: "detected",
+      label: "Original",
+      origin: { addedBy: "base" }
+    };
+
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [makeDetector("d1", signal)],
+      beforeRecommend: async () => ({
+        modify: [{ id: "s1", changes: { label: "Pre-recommend patched" } }]
+      }),
+      recommenders: [
+        {
+          id: "r1",
+          recommend: async (signals) => {
+            expect(signals[0].label).toBe("Pre-recommend patched");
+            return [];
+          }
+        }
+      ]
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.signals[0].label).toBe("Pre-recommend patched");
+    expect(report.signals[0].origin.modifiedBy).toEqual(["test-plugin"]);
+  });
+
+  it("aborts plugin stage when onError returns false", async () => {
+    const secondDetect = vi.fn().mockResolvedValue({
+      id: "s2",
+      kind: "file",
+      status: "detected",
+      label: "S2",
+      origin: { addedBy: "test" }
+    });
+
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [
+        {
+          id: "failing",
+          kind: "file",
+          detect: async () => {
+            throw new Error("abort trigger");
+          }
+        },
+        {
+          id: "skipped",
+          kind: "file",
+          detect: secondDetect
+        }
+      ],
+      onError: () => false // abort
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(secondDetect).not.toHaveBeenCalled();
+    expect(report.policyWarnings).toHaveLength(1);
+    expect(report.policyWarnings[0].message).toBe("abort trigger");
+  });
+
+  it("handles detectors returning arrays", async () => {
+    const signals: Signal[] = [
+      { id: "s1", kind: "file", status: "detected", label: "S1", origin: { addedBy: "test" } },
+      { id: "s2", kind: "git", status: "detected", label: "S2", origin: { addedBy: "test" } }
+    ];
+
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [makeDetector("multi", signals)]
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.signals).toHaveLength(2);
+    expect(report.signals.map((s) => s.id)).toEqual(["s1", "s2"]);
+  });
+
+  it("handles recommenders returning arrays", async () => {
+    const signal: Signal = {
+      id: "s1",
+      kind: "file",
+      status: "detected",
+      label: "S1",
+      origin: { addedBy: "test" }
+    };
+    const recs: Recommendation[] = [
+      { id: "r1", signalId: "s1", impact: "medium", message: "R1", origin: { addedBy: "test" } },
+      { id: "r2", signalId: "s1", impact: "low", message: "R2", origin: { addedBy: "test" } }
+    ];
+
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [makeDetector("d1", signal)],
+      recommenders: [makeRecommender("multi-rec", recs)]
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.recommendations).toHaveLength(2);
+  });
+
+  it("records warnings for recommender errors and continues", async () => {
+    const signal: Signal = {
+      id: "s1",
+      kind: "file",
+      status: "detected",
+      label: "S1",
+      origin: { addedBy: "test" }
+    };
+
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [makeDetector("d1", signal)],
+      recommenders: [
+        {
+          id: "failing-rec",
+          recommend: async () => {
+            throw new Error("recommend failed");
+          }
+        }
+      ],
+      onError: () => true
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.policyWarnings).toHaveLength(1);
+    expect(report.policyWarnings[0].stage).toBe("recommend");
+    expect(report.policyWarnings[0].message).toBe("recommend failed");
+  });
+
+  it("continues and records warning when no onError handler is provided", async () => {
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [
+        {
+          id: "failing",
+          kind: "file",
+          detect: async () => {
+            throw new Error("no handler");
+          }
+        }
+      ]
+      // no onError
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.policyWarnings).toHaveLength(1);
+    expect(report.policyWarnings[0].message).toBe("no handler");
+  });
+
+  it("handles non-Error throwables in detectors", async () => {
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [
+        {
+          id: "string-throw",
+          kind: "file",
+          detect: async () => {
+            throw "string error";
+          }
+        }
+      ]
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.policyWarnings).toHaveLength(1);
+    expect(report.policyWarnings[0].message).toBe("string error");
+  });
+
+  it("records warnings for afterDetect hook errors", async () => {
+    const signal: Signal = {
+      id: "s1",
+      kind: "file",
+      status: "detected",
+      label: "S1",
+      origin: { addedBy: "test" }
+    };
+
+    const plugin = makePlugin({
+      meta: META,
+      detectors: [makeDetector("d1", signal)],
+      afterDetect: async () => {
+        throw new Error("afterDetect failed");
+      }
+    });
+
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.policyWarnings).toHaveLength(1);
+    expect(report.policyWarnings[0].stage).toBe("afterDetect");
+  });
+
+  it("continues other plugins' detectors after one plugin aborts", async () => {
+    const plugin1 = makePlugin({
+      meta: { ...META, name: "aborter" },
+      detectors: [
+        {
+          id: "d1",
+          kind: "file",
+          detect: async () => {
+            throw new Error("abort");
+          }
+        }
+      ],
+      onError: () => false
+    });
+
+    const plugin2 = makePlugin({
+      meta: { ...META, name: "survivor" },
+      detectors: [
+        makeDetector("d2", {
+          id: "s2",
+          kind: "file",
+          status: "detected",
+          label: "S2",
+          origin: { addedBy: "survivor" }
+        })
+      ]
+    });
+
+    const report = await executePlugins([plugin1, plugin2], makeCtx());
+    expect(report.signals).toHaveLength(1);
+    expect(report.signals[0].id).toBe("s2");
+    expect(report.policyWarnings).toHaveLength(1);
+  });
+});

--- a/src/services/__tests__/policy-loader.test.ts
+++ b/src/services/__tests__/policy-loader.test.ts
@@ -1,0 +1,128 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { executePlugins } from "../policy/engine";
+import { buildBuiltinPlugin, loadPluginChain } from "../policy/loader";
+import type { PolicyContext } from "../policy/types";
+import { buildExtras } from "../readiness";
+
+function makeCtx(): PolicyContext {
+  return {
+    repoPath: "/tmp/test",
+    rootFiles: [],
+    cache: new Map()
+  };
+}
+
+describe("buildBuiltinPlugin", () => {
+  it("returns a plugin with sourceType 'builtin' and trust 'trusted-code'", () => {
+    const { plugin } = buildBuiltinPlugin();
+    expect(plugin.meta.name).toBe("builtin");
+    expect(plugin.meta.sourceType).toBe("builtin");
+    expect(plugin.meta.trust).toBe("trusted-code");
+  });
+
+  it("has detectors for all repo-scoped built-in criteria and extras", () => {
+    const { plugin, baseCriteria } = buildBuiltinPlugin();
+    const extras = buildExtras();
+    // Only repo-scoped criteria are included, plus all extras
+    const repoCriteria = baseCriteria.filter((c) => c.scope === "repo");
+    expect(plugin.detectors).toBeDefined();
+    expect(plugin.detectors!.length).toBe(repoCriteria.length + extras.length);
+  });
+
+  it("has recommenders for all repo-scoped built-in criteria and extras", () => {
+    const { plugin, baseCriteria } = buildBuiltinPlugin();
+    const extras = buildExtras();
+    const repoCriteria = baseCriteria.filter((c) => c.scope === "repo");
+    expect(plugin.recommenders).toBeDefined();
+    expect(plugin.recommenders!.length).toBe(repoCriteria.length + extras.length);
+  });
+
+  it("produces a plugin that can execute through the engine", async () => {
+    const { plugin } = buildBuiltinPlugin();
+    const report = await executePlugins([plugin], makeCtx());
+    expect(report.signals.length).toBeGreaterThan(0);
+    expect(report.pluginChain).toEqual(["builtin"]);
+    expect(report.grade).toBeDefined();
+  });
+});
+
+describe("loadPluginChain", () => {
+  it("always includes builtin as the first plugin", async () => {
+    const chain = await loadPluginChain([]);
+    expect(chain.plugins.length).toBe(1);
+    expect(chain.plugins[0].meta.name).toBe("builtin");
+    expect(chain.passRateThreshold).toBe(0.8);
+  });
+
+  it("returns empty disabledRuleIds when no policies loaded", async () => {
+    const chain = await loadPluginChain([]);
+    expect(chain.options.disabledRuleIds).toBeUndefined();
+  });
+});
+
+describe("loadPluginChain with JSON policy file", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "primer-loader-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("loads a JSON policy and returns 2-plugin chain with policy following builtin", async () => {
+    const policyPath = path.join(tmpDir, "test-policy.json");
+    await fs.writeFile(
+      policyPath,
+      JSON.stringify({ name: "test-policy", criteria: { disable: [] } })
+    );
+
+    const chain = await loadPluginChain([policyPath]);
+    expect(chain.plugins).toHaveLength(2);
+    expect(chain.plugins[0].meta.name).toBe("builtin");
+    expect(chain.plugins[1].meta.name).toBe("test-policy");
+    expect(chain.plugins[1].meta.trust).toBe("safe-declarative");
+  });
+
+  it("merges disabledRuleIds from policy criteria.disable", async () => {
+    const policyPath = path.join(tmpDir, "disable-policy.json");
+    await fs.writeFile(
+      policyPath,
+      JSON.stringify({ name: "disable-policy", criteria: { disable: ["lint-config", "readme"] } })
+    );
+
+    const chain = await loadPluginChain([policyPath]);
+    expect(chain.options.disabledRuleIds).toBeDefined();
+    expect(chain.options.disabledRuleIds).toContain("lint-config");
+    expect(chain.options.disabledRuleIds).toContain("readme");
+  });
+
+  it("picks up passRateThreshold from policy thresholds field", async () => {
+    const policyPath = path.join(tmpDir, "threshold-policy.json");
+    await fs.writeFile(
+      policyPath,
+      JSON.stringify({ name: "strict", thresholds: { passRate: 0.95 } })
+    );
+
+    const chain = await loadPluginChain([policyPath]);
+    expect(chain.passRateThreshold).toBe(0.95);
+  });
+
+  it("accepts a safe-declarative policy when jsonOnly is true", async () => {
+    const policyPath = path.join(tmpDir, "bad-policy.json");
+    // compilePolicyConfig with jsonOnly:true rejects policies that declare import sources
+    // Write a structurally-invalid policy so loadPolicy raises at parse time
+    await fs.writeFile(policyPath, JSON.stringify({ name: "bad", criteria: { disable: [] } }));
+
+    // jsonOnly flag is set when policySources comes from config (not CLI), but the
+    // file-based path always resolves to safe-declarative trust — load should succeed
+    const chain = await loadPluginChain([policyPath], { jsonOnly: true });
+    expect(chain.plugins[1].meta.trust).toBe("safe-declarative");
+  });
+});

--- a/src/services/__tests__/policy-shadow.test.ts
+++ b/src/services/__tests__/policy-shadow.test.ts
@@ -1,0 +1,402 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { compareShadow, writeShadowLog } from "../policy/shadow";
+import type { EngineReport } from "../policy/types";
+import type { ReadinessReport, ReadinessCriterionResult } from "../readiness";
+
+function makeLegacyReport(criteria: ReadinessCriterionResult[] = []): ReadinessReport {
+  return {
+    repoPath: "/tmp/test",
+    generatedAt: "2025-01-01T00:00:00.000Z",
+    isMonorepo: false,
+    apps: [],
+    pillars: [],
+    levels: [],
+    achievedLevel: 0,
+    criteria,
+    extras: []
+  };
+}
+
+function makeEngineReport(overrides: Partial<EngineReport> = {}): EngineReport {
+  return {
+    signals: [],
+    recommendations: [],
+    policyWarnings: [],
+    score: 1,
+    grade: "A",
+    pluginChain: ["builtin"],
+    ...overrides
+  };
+}
+
+function makeCriterion(id: string, status: "pass" | "fail" | "skip"): ReadinessCriterionResult {
+  return {
+    id,
+    title: `Criterion ${id}`,
+    pillar: "documentation",
+    level: 1,
+    scope: "repo",
+    impact: "high",
+    effort: "low",
+    status
+  };
+}
+
+describe("compareShadow", () => {
+  it("returns legacy report by default", () => {
+    const legacy = makeLegacyReport();
+    const engine = makeEngineReport();
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test" });
+    expect(result.usedNewEngine).toBe(false);
+    expect(result.report).toBe(legacy);
+  });
+
+  it("returns new engine report when useNewEngine is true", () => {
+    const legacy = makeLegacyReport();
+    const engine = makeEngineReport();
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test", useNewEngine: true });
+    expect(result.usedNewEngine).toBe(true);
+    expect(result.report).not.toBe(legacy);
+    expect(result.report.repoPath).toBe("/tmp/test");
+  });
+
+  it("reports no discrepancies when both engines agree", () => {
+    const legacy = makeLegacyReport([makeCriterion("readme", "pass")]);
+    const engine = makeEngineReport({
+      signals: [
+        {
+          id: "readme",
+          kind: "file",
+          status: "detected",
+          label: "README present",
+          origin: { addedBy: "builtin" },
+          metadata: {
+            pillar: "documentation",
+            level: 1,
+            scope: "repo",
+            impact: "high",
+            effort: "low",
+            checkStatus: "pass"
+          }
+        }
+      ]
+    });
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test" });
+    expect(result.discrepancies).toHaveLength(0);
+  });
+
+  it("detects status discrepancy", () => {
+    const legacy = makeLegacyReport([makeCriterion("readme", "pass")]);
+    const engine = makeEngineReport({
+      signals: [
+        {
+          id: "readme",
+          kind: "file",
+          status: "detected",
+          label: "README present",
+          origin: { addedBy: "builtin" },
+          metadata: {
+            pillar: "documentation",
+            level: 1,
+            scope: "repo",
+            impact: "high",
+            effort: "low",
+            checkStatus: "fail"
+          }
+        }
+      ]
+    });
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test" });
+    expect(result.discrepancies).toHaveLength(1);
+    expect(result.discrepancies[0].criterionId).toBe("readme");
+    expect(result.discrepancies[0].field).toBe("status");
+    expect(result.discrepancies[0].legacyValue).toBe("pass");
+    expect(result.discrepancies[0].newValue).toBe("fail");
+  });
+
+  it("detects missing criterion in new engine", () => {
+    const legacy = makeLegacyReport([makeCriterion("custom-thing", "pass")]);
+    const engine = makeEngineReport();
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test" });
+    expect(result.discrepancies).toHaveLength(1);
+    expect(result.discrepancies[0].field).toBe("presence");
+    expect(result.discrepancies[0].newValue).toBe("missing");
+  });
+
+  it("detects extra criterion in new engine", () => {
+    const legacy = makeLegacyReport();
+    const engine = makeEngineReport({
+      signals: [
+        {
+          id: "new-criterion",
+          kind: "file",
+          status: "detected",
+          label: "New",
+          origin: { addedBy: "builtin" },
+          metadata: {
+            pillar: "testing",
+            level: 1,
+            scope: "repo",
+            impact: "high",
+            effort: "low",
+            checkStatus: "pass"
+          }
+        }
+      ]
+    });
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test" });
+    expect(result.discrepancies).toHaveLength(1);
+    expect(result.discrepancies[0].field).toBe("presence");
+    expect(result.discrepancies[0].legacyValue).toBe("missing");
+  });
+
+  it("detects pillar discrepancy", () => {
+    const legacy = makeLegacyReport([
+      {
+        ...makeCriterion("readme", "pass"),
+        pillar: "documentation"
+      }
+    ]);
+    const engine = makeEngineReport({
+      signals: [
+        {
+          id: "readme",
+          kind: "file",
+          status: "detected",
+          label: "README present",
+          origin: { addedBy: "builtin" },
+          metadata: {
+            pillar: "ai-tooling",
+            level: 1,
+            scope: "repo",
+            impact: "high",
+            effort: "low",
+            checkStatus: "pass"
+          }
+        }
+      ]
+    });
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test" });
+    const pillarDisc = result.discrepancies.find((d) => d.field === "pillar");
+    expect(pillarDisc).toBeDefined();
+    expect(pillarDisc!.legacyValue).toBe("documentation");
+    expect(pillarDisc!.newValue).toBe("ai-tooling");
+  });
+
+  it("detects level discrepancy", () => {
+    const legacy = makeLegacyReport([
+      {
+        ...makeCriterion("readme", "pass"),
+        level: 1
+      }
+    ]);
+    const engine = makeEngineReport({
+      signals: [
+        {
+          id: "readme",
+          kind: "file",
+          status: "detected",
+          label: "README present",
+          origin: { addedBy: "builtin" },
+          metadata: {
+            pillar: "documentation",
+            level: 3,
+            scope: "repo",
+            impact: "high",
+            effort: "low",
+            checkStatus: "pass"
+          }
+        }
+      ]
+    });
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test" });
+    const levelDisc = result.discrepancies.find((d) => d.field === "level");
+    expect(levelDisc).toBeDefined();
+    expect(levelDisc!.legacyValue).toBe(1);
+    expect(levelDisc!.newValue).toBe(3);
+  });
+
+  it("detects impact discrepancy", () => {
+    const legacy = makeLegacyReport([{ ...makeCriterion("readme", "pass"), impact: "high" }]);
+    const engine = makeEngineReport({
+      signals: [
+        {
+          id: "readme",
+          kind: "file",
+          status: "detected",
+          label: "README present",
+          origin: { addedBy: "builtin" },
+          metadata: {
+            pillar: "documentation",
+            level: 1,
+            scope: "repo",
+            impact: "medium",
+            effort: "low",
+            checkStatus: "pass"
+          }
+        }
+      ]
+    });
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test" });
+    const disc = result.discrepancies.find((d) => d.field === "impact");
+    expect(disc).toBeDefined();
+    expect(disc!.legacyValue).toBe("high");
+    expect(disc!.newValue).toBe("medium");
+  });
+
+  it("detects effort discrepancy", () => {
+    const legacy = makeLegacyReport([{ ...makeCriterion("readme", "pass"), effort: "low" }]);
+    const engine = makeEngineReport({
+      signals: [
+        {
+          id: "readme",
+          kind: "file",
+          status: "detected",
+          label: "README present",
+          origin: { addedBy: "builtin" },
+          metadata: {
+            pillar: "documentation",
+            level: 1,
+            scope: "repo",
+            impact: "high",
+            effort: "high",
+            checkStatus: "pass"
+          }
+        }
+      ]
+    });
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test" });
+    const disc = result.discrepancies.find((d) => d.field === "effort");
+    expect(disc).toBeDefined();
+    expect(disc!.legacyValue).toBe("low");
+    expect(disc!.newValue).toBe("high");
+  });
+
+  it("filters area-scoped legacy criteria before comparison to avoid false-positive presence discrepancies", () => {
+    const areaCriterion: ReadinessCriterionResult = {
+      ...makeCriterion("area-readme", "skip"),
+      scope: "area"
+    };
+    // Legacy report has an area-scoped criterion; engine has none (engine only runs repo-scoped)
+    const legacy = makeLegacyReport([makeCriterion("readme", "pass"), areaCriterion]);
+    const engine = makeEngineReport({
+      signals: [
+        {
+          id: "readme",
+          kind: "file",
+          status: "detected",
+          label: "README present",
+          origin: { addedBy: "builtin" },
+          metadata: {
+            pillar: "documentation",
+            level: 1,
+            scope: "repo",
+            impact: "high",
+            effort: "low",
+            checkStatus: "pass"
+          }
+        }
+      ]
+    });
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test" });
+    // area-readme must not produce a "presence: missing" discrepancy
+    const presenceDiscs = result.discrepancies.filter((d) => d.field === "presence");
+    expect(presenceDiscs).toHaveLength(0);
+    expect(result.discrepancies).toHaveLength(0);
+  });
+
+  it("asserts both values for extra criterion in new engine", () => {
+    const legacy = makeLegacyReport();
+    const engine = makeEngineReport({
+      signals: [
+        {
+          id: "new-criterion",
+          kind: "file",
+          status: "detected",
+          label: "New",
+          origin: { addedBy: "builtin" },
+          metadata: {
+            pillar: "testing",
+            level: 1,
+            scope: "repo",
+            impact: "high",
+            effort: "low",
+            checkStatus: "pass"
+          }
+        }
+      ]
+    });
+    const result = compareShadow(legacy, engine, { repoPath: "/tmp/test" });
+    expect(result.discrepancies).toHaveLength(1);
+    expect(result.discrepancies[0].legacyValue).toBe("missing");
+    expect(result.discrepancies[0].newValue).toBe("exists");
+  });
+});
+
+describe("writeShadowLog", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "primer-shadow-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("is a no-op when discrepancies array is empty", async () => {
+    await writeShadowLog(tmpDir, []);
+    const logPath = path.join(tmpDir, ".primer-cache", "shadow-mode.log");
+    let exists = false;
+    try {
+      await fs.access(logPath);
+      exists = true;
+    } catch {
+      // expected — file should not be created
+    }
+    expect(exists).toBe(false);
+  });
+
+  it("creates the log file and appends discrepancy details", async () => {
+    const discrepancies = [
+      { criterionId: "readme", field: "status", legacyValue: "pass", newValue: "fail" }
+    ];
+    await writeShadowLog(tmpDir, discrepancies);
+    const logPath = path.join(tmpDir, ".primer-cache", "shadow-mode.log");
+    const content = await fs.readFile(logPath, "utf-8");
+    expect(content).toContain('["readme"] status');
+    expect(content).toContain('"pass"');
+    expect(content).toContain('"fail"');
+  });
+
+  it("appends on successive calls (does not overwrite)", async () => {
+    const d = [{ criterionId: "readme", field: "status", legacyValue: "pass", newValue: "fail" }];
+    await writeShadowLog(tmpDir, d);
+    await writeShadowLog(tmpDir, d);
+    const logPath = path.join(tmpDir, ".primer-cache", "shadow-mode.log");
+    const content = await fs.readFile(logPath, "utf-8");
+    const matches = content.match(/\["readme"\] status/g) ?? [];
+    expect(matches).toHaveLength(2);
+  });
+
+  it("creates the .primer-cache directory if it does not exist", async () => {
+    // No .primer-cache dir created — writeShadowLog must mkdir it
+    const discrepancies = [
+      {
+        criterionId: "codeowners",
+        field: "pillar",
+        legacyValue: "security-governance",
+        newValue: "documentation"
+      }
+    ];
+    await writeShadowLog(tmpDir, discrepancies);
+    const logPath = path.join(tmpDir, ".primer-cache", "shadow-mode.log");
+    const stat = await fs.stat(logPath);
+    expect(stat.isFile()).toBe(true);
+  });
+});

--- a/src/services/__tests__/readiness-baseline.test.ts
+++ b/src/services/__tests__/readiness-baseline.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Phase C: Characterization baselines.
+ *
+ * These tests lock the existing ReadinessReport shape, pillar/level summaries,
+ * and command output behavior. They serve as the parity gate before the new
+ * plugin engine is wired into the readiness pipeline (Phase G).
+ *
+ * If any of these fail after engine integration, the compatibility adapter
+ * is incorrect or incomplete.
+ */
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { runReadinessReport, buildCriteria, buildExtras, groupPillars } from "../readiness";
+
+describe("ReadinessReport shape baseline", () => {
+  let repoPath: string;
+
+  beforeEach(async () => {
+    repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "primer-baseline-"));
+    await fs.writeFile(
+      path.join(repoPath, "package.json"),
+      JSON.stringify({ name: "baseline-repo", scripts: { build: "tsc", test: "vitest" } })
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+
+  it("locks the top-level report fields", async () => {
+    const report = await runReadinessReport({ repoPath });
+    const keys = Object.keys(report).sort();
+    expect(keys).toEqual([
+      "achievedLevel",
+      "apps",
+      "areaReports",
+      "criteria",
+      "engine",
+      "extras",
+      "generatedAt",
+      "isMonorepo",
+      "levels",
+      "pillars",
+      "policies",
+      "repoPath"
+    ]);
+  });
+
+  it("locks ReadinessCriterionResult field set", async () => {
+    const report = await runReadinessReport({ repoPath });
+    const criterion = report.criteria[0];
+    expect(criterion).toHaveProperty("id");
+    expect(criterion).toHaveProperty("title");
+    expect(criterion).toHaveProperty("pillar");
+    expect(criterion).toHaveProperty("level");
+    expect(criterion).toHaveProperty("scope");
+    expect(criterion).toHaveProperty("impact");
+    expect(criterion).toHaveProperty("effort");
+    expect(criterion).toHaveProperty("status");
+  });
+
+  it("locks pillar summary fields", async () => {
+    const report = await runReadinessReport({ repoPath });
+    const pillar = report.pillars[0];
+    expect(pillar).toHaveProperty("id");
+    expect(pillar).toHaveProperty("name");
+    expect(pillar).toHaveProperty("passed");
+    expect(pillar).toHaveProperty("total");
+    expect(pillar).toHaveProperty("passRate");
+  });
+
+  it("locks level summary fields", async () => {
+    const report = await runReadinessReport({ repoPath });
+    const level = report.levels[0];
+    expect(level).toHaveProperty("level");
+    expect(level).toHaveProperty("name");
+    expect(level).toHaveProperty("passed");
+    expect(level).toHaveProperty("total");
+    expect(level).toHaveProperty("passRate");
+    expect(level).toHaveProperty("achieved");
+  });
+
+  it("locks the allowed ReadinessStatus values", async () => {
+    const report = await runReadinessReport({ repoPath });
+    const statuses = new Set(report.criteria.map((c) => c.status));
+    // Every status must be one of the 3 allowed values
+    for (const status of statuses) {
+      expect(["pass", "fail", "skip"]).toContain(status);
+    }
+  });
+
+  it("locks the 9 pillar IDs", async () => {
+    const report = await runReadinessReport({ repoPath });
+    const pillarIds = report.pillars.map((p) => p.id).sort();
+    expect(pillarIds).toEqual([
+      "ai-tooling",
+      "build-system",
+      "code-quality",
+      "dev-environment",
+      "documentation",
+      "observability",
+      "security-governance",
+      "style-validation",
+      "testing"
+    ]);
+  });
+
+  it("locks the 5 maturity level names", async () => {
+    const report = await runReadinessReport({ repoPath });
+    const levelNames = report.levels.map((l) => l.name);
+    expect(levelNames).toEqual([
+      "Functional",
+      "Documented",
+      "Standardized",
+      "Optimized",
+      "Autonomous"
+    ]);
+  });
+});
+
+describe("countStatus baseline", () => {
+  it("excludes skip items from total and passed counts", async () => {
+    const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "primer-cs-"));
+    await fs.writeFile(path.join(repoPath, "package.json"), JSON.stringify({ name: "count-repo" }));
+
+    try {
+      const report = await runReadinessReport({ repoPath });
+      // Verify skips don't inflate totals
+      for (const pillar of report.pillars) {
+        const criteria = report.criteria.filter((c) => c.pillar === pillar.id);
+        const nonSkip = criteria.filter((c) => c.status !== "skip");
+        expect(pillar.total).toBe(nonSkip.length);
+      }
+    } finally {
+      await fs.rm(repoPath, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("groupPillars baseline", () => {
+  it("groups pillars into repo-health and ai-setup", async () => {
+    const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "primer-gp-"));
+    await fs.writeFile(path.join(repoPath, "package.json"), JSON.stringify({ name: "group-repo" }));
+
+    try {
+      const report = await runReadinessReport({ repoPath });
+      const groups = groupPillars(report.pillars);
+      expect(groups).toHaveLength(2);
+      expect(groups[0].group).toBe("repo-health");
+      expect(groups[0].label).toBe("Repo Health");
+      expect(groups[1].group).toBe("ai-setup");
+      expect(groups[1].label).toBe("AI Setup");
+      // ai-tooling pillar is in the ai-setup group
+      expect(groups[1].pillars.map((p) => p.id)).toContain("ai-tooling");
+    } finally {
+      await fs.rm(repoPath, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("buildCriteria baseline", () => {
+  it("locks the set of built-in criterion IDs", () => {
+    const criteria = buildCriteria();
+    const ids = criteria.map((c) => c.id).sort();
+    expect(ids).toEqual([
+      "area-build-script",
+      "area-instructions",
+      "area-readme",
+      "area-test-script",
+      "build-script",
+      "ci-config",
+      "codeowners",
+      "contributing",
+      "copilot-skills",
+      "custom-agents",
+      "custom-instructions",
+      "dependabot",
+      "env-example",
+      "format-config",
+      "license",
+      "lint-config",
+      "lockfile",
+      "mcp-config",
+      "observability",
+      "readme",
+      "security-policy",
+      "test-script",
+      "typecheck-config"
+    ]);
+  });
+
+  it("locks the impact and effort allowed values", () => {
+    const criteria = buildCriteria();
+    for (const c of criteria) {
+      expect(["high", "medium", "low"]).toContain(c.impact);
+      expect(["low", "medium", "high"]).toContain(c.effort);
+    }
+  });
+});
+
+describe("buildExtras baseline", () => {
+  it("locks the set of built-in extra IDs", () => {
+    const extras = buildExtras();
+    const ids = extras.map((e) => e.id).sort();
+    expect(ids).toEqual(["agents-doc", "architecture-doc", "pr-template", "pre-commit"]);
+  });
+});

--- a/src/services/policy/adapter.ts
+++ b/src/services/policy/adapter.ts
@@ -1,0 +1,192 @@
+/**
+ * Phase G: Compatibility adapter.
+ *
+ * Maps `EngineReport` from the new plugin system to the legacy
+ * `ReadinessReport` shape so all existing surfaces (CLI, HTML, VS Code)
+ * continue to work without changes.
+ *
+ * Key mapping rules:
+ * - Signal metadata carries pillar/level/scope/impact/effort/checkStatus
+ * - checkStatus determines ReadinessCriterionResult.status
+ * - Extras are signals without pillar metadata
+ * - Pillar/level summaries and achievedLevel are recomputed from criteria
+ */
+import type {
+  ReadinessReport,
+  ReadinessCriterionResult,
+  ReadinessExtraResult,
+  ReadinessPillarSummary,
+  ReadinessLevelSummary,
+  ReadinessPillar,
+  ReadinessScope,
+  ReadinessStatus
+} from "../readiness";
+
+import type { EngineReport, Signal, Recommendation } from "./types";
+
+const PILLAR_NAMES: Record<ReadinessPillar, string> = {
+  "style-validation": "Style & Validation",
+  "build-system": "Build System",
+  testing: "Testing",
+  documentation: "Documentation",
+  "dev-environment": "Dev Environment",
+  "code-quality": "Code Quality",
+  observability: "Observability",
+  "security-governance": "Security & Governance",
+  "ai-tooling": "AI Tooling"
+};
+
+const LEVEL_NAMES: Record<number, string> = {
+  1: "Functional",
+  2: "Documented",
+  3: "Standardized",
+  4: "Optimized",
+  5: "Autonomous"
+};
+
+type AdapterOptions = {
+  repoPath: string;
+  isMonorepo?: boolean;
+  apps?: Array<{ name: string; path: string }>;
+  passRateThreshold?: number;
+};
+
+/**
+ * Convert an EngineReport to a legacy ReadinessReport.
+ *
+ * This is the bridge that lets the new plugin engine power existing
+ * readiness surfaces without any surface-level changes.
+ */
+export function engineReportToReadiness(
+  report: EngineReport,
+  options: AdapterOptions
+): ReadinessReport {
+  const passRateThreshold = options.passRateThreshold ?? 0.8;
+  const { criteria, extras } = partitionSignals(report.signals, report.recommendations);
+
+  const pillars = summarizePillars(criteria);
+  const levels = summarizeLevels(criteria, passRateThreshold);
+  const achievedLevel = levels
+    .filter((l) => l.achieved)
+    .reduce((max, l) => Math.max(max, l.level), 0);
+
+  return {
+    repoPath: options.repoPath,
+    generatedAt: new Date().toISOString(),
+    isMonorepo: options.isMonorepo ?? false,
+    apps: options.apps ?? [],
+    pillars,
+    levels,
+    achievedLevel,
+    criteria,
+    extras,
+    policies: {
+      chain: report.pluginChain as string[],
+      criteriaCount: criteria.length
+    },
+    engine: {
+      signals: report.signals,
+      recommendations: report.recommendations,
+      policyWarnings: report.policyWarnings,
+      score: report.score,
+      grade: report.grade
+    }
+  };
+}
+
+/**
+ * Partition engine signals into legacy criteria results and extra results.
+ *
+ * A signal is treated as a "criterion" if its metadata contains `pillar`.
+ * Everything else is an "extra".
+ */
+function partitionSignals(
+  signals: ReadonlyArray<Signal>,
+  _recommendations: ReadonlyArray<Recommendation>
+): { criteria: ReadinessCriterionResult[]; extras: ReadinessExtraResult[] } {
+  const criteria: ReadinessCriterionResult[] = [];
+  const extras: ReadinessExtraResult[] = [];
+
+  for (const signal of signals) {
+    const meta = (signal.metadata ?? {}) as Record<string, unknown>;
+    if (meta.pillar) {
+      criteria.push(signalToCriterion(signal, meta));
+    } else {
+      extras.push(signalToExtra(signal, meta));
+    }
+  }
+
+  return { criteria, extras };
+}
+
+function signalToCriterion(
+  signal: Signal,
+  meta: Record<string, unknown>
+): ReadinessCriterionResult {
+  const checkStatus = meta.checkStatus as string | undefined;
+  const status: ReadinessStatus =
+    checkStatus === "pass" ? "pass" : checkStatus === "fail" ? "fail" : "skip";
+
+  return {
+    id: signal.id,
+    title: signal.label,
+    pillar: meta.pillar as ReadinessPillar,
+    level: (meta.level as number) ?? 1,
+    scope: (meta.scope as ReadinessScope) ?? "repo",
+    impact: (meta.impact as "high" | "medium" | "low") ?? "medium",
+    effort: (meta.effort as "low" | "medium" | "high") ?? "medium",
+    status,
+    reason: signal.reason,
+    evidence: signal.evidence
+  };
+}
+
+function signalToExtra(signal: Signal, meta: Record<string, unknown>): ReadinessExtraResult {
+  const checkStatus = meta.checkStatus as string | undefined;
+  const status: ReadinessStatus =
+    checkStatus === "pass" ? "pass" : checkStatus === "fail" ? "fail" : "skip";
+  return {
+    id: signal.id,
+    title: signal.label,
+    status,
+    reason: signal.reason
+  };
+}
+
+function summarizePillars(criteria: ReadinessCriterionResult[]): ReadinessPillarSummary[] {
+  return (Object.keys(PILLAR_NAMES) as ReadinessPillar[]).map((pillar) => {
+    const items = criteria.filter((c) => c.pillar === pillar);
+    const { passed, total } = countStatus(items);
+    return {
+      id: pillar,
+      name: PILLAR_NAMES[pillar],
+      passed,
+      total,
+      passRate: total ? passed / total : 0
+    };
+  });
+}
+
+function summarizeLevels(
+  criteria: ReadinessCriterionResult[],
+  passRateThreshold: number
+): ReadinessLevelSummary[] {
+  const summaries: ReadinessLevelSummary[] = [];
+  for (let level = 1; level <= 5; level++) {
+    const items = criteria.filter((c) => c.level === level);
+    const { passed, total } = countStatus(items);
+    const passRate = total ? passed / total : 0;
+    summaries.push({ level, name: LEVEL_NAMES[level], passed, total, passRate, achieved: false });
+  }
+  for (const summary of summaries) {
+    const allPrior = summaries.filter((s) => s.level <= summary.level);
+    summary.achieved = allPrior.every((s) => s.total > 0 && s.passRate >= passRateThreshold);
+  }
+  return summaries;
+}
+
+function countStatus(items: ReadinessCriterionResult[]): { passed: number; total: number } {
+  const relevant = items.filter((item) => item.status !== "skip");
+  const passed = relevant.filter((item) => item.status === "pass").length;
+  return { passed, total: relevant.length };
+}

--- a/src/services/policy/compiler.ts
+++ b/src/services/policy/compiler.ts
@@ -1,0 +1,256 @@
+/**
+ * Phase E: Declarative-to-Plugin Compiler.
+ *
+ * Compiles a declarative PolicyConfig (JSON policy) into a PolicyPlugin adapter
+ * so that both imperative and declarative policies share the same runtime.
+ *
+ * Declarative policies can:
+ *   - disable criteria/extras → mapped to EngineOptions.disabledRuleIds
+ *   - override criterion metadata → mapped to afterDetect hook (SignalPatch.modify)
+ *   - add new criteria → mapped to detectors + recommenders
+ *   - set thresholds → returned alongside the plugin for engine-level use
+ */
+import type { PolicyConfig, ExtraDefinition } from "../policy";
+import type { ReadinessCriterion, ReadinessContext } from "../readiness";
+
+import type {
+  PolicyPlugin,
+  Detector,
+  RecommendationImpact,
+  Recommender,
+  Signal,
+  SignalPatch,
+  PolicyContext
+} from "./types";
+
+export type CompilationResult = {
+  plugin: PolicyPlugin;
+  /** Criterion/extra IDs to disable at engine level. */
+  disabledIds: string[];
+  /** Pass-rate threshold from the policy (undefined if not set). */
+  passRateThreshold?: number;
+};
+
+/**
+ * Compile a declarative PolicyConfig into a PolicyPlugin.
+ *
+ * The compiled plugin has trust "safe-declarative" and sourceType "json".
+ * It cannot contain arbitrary code — only metadata overrides and static checks.
+ */
+export function compilePolicyConfig(
+  config: PolicyConfig,
+  /** Base criteria used for metadata override resolution. */
+  _baseCriteria: ReadonlyArray<ReadinessCriterion>
+): CompilationResult {
+  const disabledIds: string[] = [];
+  const detectors: Detector[] = [];
+  const recommenders: Recommender[] = [];
+  let afterDetect:
+    | ((signals: ReadonlyArray<Signal>, ctx: PolicyContext) => Promise<SignalPatch | undefined>)
+    | undefined;
+
+  // ── Collect disabled IDs ──
+  if (config.criteria?.disable?.length) {
+    disabledIds.push(...config.criteria.disable);
+  }
+  if (config.extras?.disable?.length) {
+    disabledIds.push(...config.extras.disable);
+  }
+
+  // ── Build afterDetect hook for metadata overrides ──
+  if (config.criteria?.override && Object.keys(config.criteria.override).length > 0) {
+    const overrides = config.criteria.override;
+    afterDetect = async (signals) => {
+      const modifications: SignalPatch["modify"] = [];
+      for (const [id, changes] of Object.entries(overrides)) {
+        // Only modify signals that exist
+        const exists = signals.some((s) => s.id === id);
+        if (exists) {
+          // Map criterion metadata overrides to signal label/metadata changes
+          const signalChanges: Record<string, unknown> = {};
+          if (changes.title) {
+            signalChanges.label = changes.title;
+          }
+          // Store remaining overrides in metadata
+          const meta: Record<string, unknown> = {};
+          if (changes.pillar) meta.pillar = changes.pillar;
+          if (changes.level !== undefined) meta.level = changes.level;
+          if (changes.scope) meta.scope = changes.scope;
+          if (changes.impact) meta.impact = changes.impact;
+          if (changes.effort) meta.effort = changes.effort;
+          if (Object.keys(meta).length > 0) {
+            signalChanges.metadata = meta;
+          }
+          if (Object.keys(signalChanges).length > 0) {
+            modifications.push({
+              id,
+              changes: signalChanges as Partial<Omit<Signal, "id" | "origin">>
+            });
+          }
+        }
+      }
+      return modifications.length > 0 ? { modify: modifications } : undefined;
+    };
+  }
+
+  // ── Build detectors + recommenders from criteria.add ──
+  if (config.criteria?.add?.length) {
+    for (const criterion of config.criteria.add) {
+      detectors.push(criterionToDetector(criterion));
+      recommenders.push(criterionToRecommender(criterion));
+    }
+  }
+
+  // ── Build detectors + recommenders from extras.add ──
+  if (config.extras?.add?.length) {
+    for (const extra of config.extras.add) {
+      detectors.push(extraToDetector(extra));
+      recommenders.push(extraToRecommender(extra));
+    }
+  }
+
+  const plugin: PolicyPlugin = {
+    meta: {
+      name: config.name,
+      version: config.version,
+      sourceType: "json",
+      trust: "safe-declarative"
+    },
+    ...(detectors.length > 0 ? { detectors } : {}),
+    ...(afterDetect ? { afterDetect } : {}),
+    ...(recommenders.length > 0 ? { recommenders } : {})
+  };
+
+  return {
+    plugin,
+    disabledIds,
+    passRateThreshold: config.thresholds?.passRate
+  };
+}
+
+function criterionToDetector(criterion: ReadinessCriterion): Detector {
+  return {
+    id: criterion.id,
+    kind: mapScope(criterion.scope),
+    detect: async (ctx) => {
+      const readinessCtx = policyCtxToReadinessCtx(ctx);
+      const result = await criterion.check(readinessCtx);
+      return {
+        id: criterion.id,
+        kind: mapScope(criterion.scope),
+        status: result.status === "skip" ? "not-detected" : "detected",
+        label: criterion.title,
+        evidence: result.evidence,
+        reason: result.reason,
+        origin: { addedBy: `compiled:${criterion.id}` },
+        metadata: {
+          pillar: criterion.pillar,
+          level: criterion.level,
+          scope: criterion.scope,
+          impact: criterion.impact,
+          effort: criterion.effort,
+          checkStatus: result.status
+        }
+      };
+    }
+  };
+}
+
+function criterionToRecommender(criterion: ReadinessCriterion): Recommender {
+  return {
+    id: `${criterion.id}-rec`,
+    recommend: async (signals) => {
+      const signal = signals.find((s) => s.id === criterion.id);
+      if (!signal) return [];
+      const checkStatus = (signal.metadata as Record<string, unknown>)?.checkStatus;
+      if (checkStatus !== "fail") return [];
+      // Read impact from signal metadata at call time so afterDetect overrides
+      // (e.g. from a declarative policy's override block) are reflected in scoring.
+      const runtimeImpact = (signal.metadata as Record<string, unknown>)?.impact as
+        | RecommendationImpact
+        | undefined;
+      const impact =
+        runtimeImpact ??
+        (criterion.impact === "high" ? "high" : criterion.impact === "medium" ? "medium" : "low");
+      return {
+        id: `${criterion.id}-fix`,
+        signalId: criterion.id,
+        impact,
+        message: signal.reason ?? `Fix: ${criterion.title}`,
+        origin: { addedBy: `compiled:${criterion.id}` }
+      };
+    }
+  };
+}
+
+function extraToDetector(extra: ExtraDefinition): Detector {
+  return {
+    id: extra.id,
+    kind: "custom",
+    detect: async (ctx) => {
+      const readinessCtx = policyCtxToReadinessCtx(ctx);
+      const result = await extra.check(readinessCtx);
+      return {
+        id: extra.id,
+        kind: "custom" as const,
+        status: "detected" as const,
+        label: extra.title,
+        reason: result.reason,
+        origin: { addedBy: `compiled:${extra.id}` },
+        metadata: { checkStatus: result.status }
+      };
+    }
+  };
+}
+
+function extraToRecommender(extra: ExtraDefinition): Recommender {
+  return {
+    id: `${extra.id}-rec`,
+    recommend: async (signals) => {
+      const signal = signals.find((s) => s.id === extra.id);
+      if (!signal) return [];
+      const checkStatus = (signal.metadata as Record<string, unknown>)?.checkStatus;
+      if (checkStatus !== "fail") return [];
+      return {
+        id: `${extra.id}-fix`,
+        signalId: extra.id,
+        impact: "low" as const,
+        message: signal.reason ?? `Fix: ${extra.title}`,
+        origin: { addedBy: `compiled:${extra.id}` }
+      };
+    }
+  };
+}
+
+function mapScope(scope: string): "file" | "git" | "custom" {
+  switch (scope) {
+    case "repo":
+      return "file";
+    case "app":
+      return "file";
+    case "area":
+      return "file";
+    default:
+      return "custom";
+  }
+}
+
+/**
+ * Bridge from PolicyContext to ReadinessContext.
+ * Used by compiled detectors to run legacy check functions.
+ */
+function policyCtxToReadinessCtx(ctx: PolicyContext): ReadinessContext {
+  return {
+    repoPath: ctx.repoPath,
+    analysis: {
+      path: ctx.repoPath,
+      isGitRepo: true,
+      languages: [],
+      frameworks: [],
+      isMonorepo: false
+    },
+    apps: [],
+    rootFiles: ctx.rootFiles,
+    rootPackageJson: ctx.rootPackageJson
+  };
+}

--- a/src/services/policy/engine.ts
+++ b/src/services/policy/engine.ts
@@ -1,0 +1,150 @@
+import type {
+  PolicyPlugin,
+  PolicyContext,
+  Signal,
+  Recommendation,
+  PolicyWarning,
+  EngineReport,
+  PluginStage
+} from "./types";
+import {
+  applySignalPatch,
+  applyRecommendationPatch,
+  resolveSupersedes,
+  calculateScore
+} from "./types";
+
+export type EngineOptions = {
+  /** IDs of rules to skip entirely (detectors + recommenders). */
+  disabledRuleIds?: Set<string>;
+};
+
+/**
+ * Execute a chain of plugins through the deterministic pipeline:
+ *   1. All detectors (all plugins, source order)
+ *   2. afterDetect hooks (all plugins, source order)
+ *   3. beforeRecommend hooks (all plugins, source order)
+ *   4. All recommenders (all plugins, source order)
+ *   5. afterRecommend hooks (all plugins, source order)
+ *   6. Resolve supersedes
+ *   7. Engine-level scoring
+ */
+export async function executePlugins(
+  plugins: PolicyPlugin[],
+  ctx: PolicyContext,
+  options?: EngineOptions
+): Promise<EngineReport> {
+  const warnings: PolicyWarning[] = [];
+  const disabledIds = options?.disabledRuleIds ?? new Set<string>();
+
+  // ── Stage 1: Detect ──
+  let signals: Signal[] = [];
+  for (const plugin of plugins) {
+    if (!plugin.detectors?.length) continue;
+    for (const detector of plugin.detectors) {
+      if (disabledIds.has(detector.id)) continue;
+      try {
+        const result = await detector.detect(ctx);
+        const emitted = Array.isArray(result) ? result : [result];
+        signals.push(...emitted);
+      } catch (err) {
+        const cont = handleError(plugin, err, "detect", ctx, warnings);
+        if (!cont) break;
+      }
+    }
+  }
+
+  // ── Stage 2: afterDetect hooks ──
+  // Hook stages (2, 3, 5) do not honor onError abort on the outer plugin loop.
+  // Each hook is a single call per plugin, so "abort" only applies to inner
+  // detector/recommender loops in stages 1 and 4.
+  for (const plugin of plugins) {
+    if (!plugin.afterDetect) continue;
+    try {
+      const patch = await plugin.afterDetect(signals, ctx);
+      if (patch) {
+        signals = applySignalPatch(signals, patch, plugin.meta.name);
+      }
+    } catch (err) {
+      handleError(plugin, err, "afterDetect", ctx, warnings);
+    }
+  }
+
+  // ── Stage 3: beforeRecommend hooks ──
+  for (const plugin of plugins) {
+    if (!plugin.beforeRecommend) continue;
+    try {
+      const patch = await plugin.beforeRecommend(signals, ctx);
+      if (patch) {
+        signals = applySignalPatch(signals, patch, plugin.meta.name);
+      }
+    } catch (err) {
+      handleError(plugin, err, "beforeRecommend", ctx, warnings);
+    }
+  }
+
+  // ── Stage 4: Recommend ──
+  let recommendations: Recommendation[] = [];
+  for (const plugin of plugins) {
+    if (!plugin.recommenders?.length) continue;
+    for (const recommender of plugin.recommenders) {
+      if (disabledIds.has(recommender.id)) continue;
+      try {
+        const result = await recommender.recommend(signals, ctx);
+        const emitted = Array.isArray(result) ? result : [result];
+        recommendations.push(...emitted);
+      } catch (err) {
+        const cont = handleError(plugin, err, "recommend", ctx, warnings);
+        if (!cont) break;
+      }
+    }
+  }
+
+  // ── Stage 5: afterRecommend hooks ──
+  for (const plugin of plugins) {
+    if (!plugin.afterRecommend) continue;
+    try {
+      const patch = await plugin.afterRecommend(recommendations, signals, ctx);
+      if (patch) {
+        recommendations = applyRecommendationPatch(recommendations, patch, plugin.meta.name);
+      }
+    } catch (err) {
+      handleError(plugin, err, "afterRecommend", ctx, warnings);
+    }
+  }
+
+  // ── Stage 6: Resolve supersedes ──
+  recommendations = resolveSupersedes(recommendations);
+
+  // ── Stage 7: Score ──
+  const { score, grade } = calculateScore(signals, recommendations);
+
+  return {
+    signals,
+    recommendations,
+    policyWarnings: warnings,
+    score,
+    grade,
+    pluginChain: plugins.map((p) => p.meta.name)
+  };
+}
+
+function handleError(
+  plugin: PolicyPlugin,
+  err: unknown,
+  stage: PluginStage,
+  ctx: PolicyContext,
+  warnings: PolicyWarning[]
+): boolean {
+  const error = err instanceof Error ? err : new Error(String(err));
+  // Always record the warning for audit trail, even on abort
+  warnings.push({
+    pluginName: plugin.meta.name,
+    stage,
+    message: error.message
+  });
+  if (plugin.onError) {
+    return plugin.onError(error, stage, ctx);
+  }
+  return true;
+}

--- a/src/services/policy/index.ts
+++ b/src/services/policy/index.ts
@@ -1,0 +1,31 @@
+export type {
+  Signal,
+  SignalKind,
+  SignalStatus,
+  SignalPatch,
+  Recommendation,
+  RecommendationImpact,
+  RecommendationPatch,
+  PolicyWarning,
+  Provenance,
+  PolicyContext,
+  Detector,
+  Recommender,
+  PolicyPlugin,
+  PluginMeta,
+  PluginTrust,
+  PluginSourceType,
+  PluginStage,
+  EngineReport,
+  Grade
+} from "./types";
+export { calculateScore } from "./types";
+export { executePlugins } from "./engine";
+export type { EngineOptions } from "./engine";
+export { compilePolicyConfig } from "./compiler";
+export type { CompilationResult } from "./compiler";
+export { buildBuiltinPlugin, loadPluginChain } from "./loader";
+export type { LoadedChain } from "./loader";
+export { engineReportToReadiness } from "./adapter";
+export { compareShadow, writeShadowLog } from "./shadow";
+export type { ShadowResult, ShadowDiscrepancy } from "./shadow";

--- a/src/services/policy/loader.ts
+++ b/src/services/policy/loader.ts
@@ -1,0 +1,152 @@
+/**
+ * Phase F: Plugin loader and chain composition.
+ *
+ * Resolves built-in, local/npm imperative, and compiled JSON plugins
+ * into an ordered plugin chain. Source/load order determines execution.
+ *
+ * Loader responsibilities:
+ *   - Build the built-in plugin from current `buildCriteria`/`buildExtras`
+ *   - Load imperative (.ts/.js) plugins with trust "trusted-code"
+ *   - Load declarative (.json) policies via the DSL compiler (trust "safe-declarative")
+ *   - Aggregate disabledIds across all compiled policies into EngineOptions
+ *   - Return the ready-to-execute plugin chain + engine options
+ */
+import type { PolicyConfig } from "../policy";
+import { loadPolicy } from "../policy";
+import type { ReadinessCriterion } from "../readiness";
+import { buildCriteria, buildExtras } from "../readiness";
+
+import { compilePolicyConfig } from "./compiler";
+import type { CompilationResult } from "./compiler";
+import type { EngineOptions } from "./engine";
+import type { PolicyPlugin } from "./types";
+
+export type LoadedChain = {
+  plugins: PolicyPlugin[];
+  options: EngineOptions;
+  /** Pass-rate threshold (last policy wins). */
+  passRateThreshold: number;
+};
+
+/**
+ * Build the built-in plugin from the current `buildCriteria`/`buildExtras`.
+ * Each criterion becomes a detector + recommender pair.
+ * Extras also become detector + recommender pairs.
+ */
+export function buildBuiltinPlugin(): { plugin: PolicyPlugin; baseCriteria: ReadinessCriterion[] } {
+  const baseCriteria = buildCriteria();
+  const baseExtras = buildExtras();
+
+  // Only include repo-scoped criteria — app/area-scoped criteria need
+  // iteration context that the engine doesn't provide yet.
+  const repoCriteria = baseCriteria.filter((c) => c.scope === "repo");
+
+  const compiledCriteria = compilePolicyConfig(
+    {
+      name: "__builtin__",
+      criteria: { add: repoCriteria },
+      extras: { add: baseExtras }
+    },
+    []
+  );
+
+  const plugin: PolicyPlugin = {
+    ...compiledCriteria.plugin,
+    meta: {
+      ...compiledCriteria.plugin.meta,
+      name: "builtin",
+      sourceType: "builtin",
+      trust: "trusted-code"
+    }
+  };
+
+  return { plugin, baseCriteria };
+}
+
+/**
+ * Load a chain of plugins from policy sources.
+ *
+ * @param policySources - Policy file paths or npm specifiers
+ * @param options - Loading options
+ * @returns Ready-to-execute plugin chain and engine options
+ */
+export async function loadPluginChain(
+  policySources: string[],
+  options?: { jsonOnly?: boolean }
+): Promise<LoadedChain> {
+  const { plugin: builtinPlugin, baseCriteria } = buildBuiltinPlugin();
+  const plugins: PolicyPlugin[] = [builtinPlugin];
+  const allDisabledIds: string[] = [];
+  let passRateThreshold = 0.8;
+
+  for (const source of policySources) {
+    const policyConfig: PolicyConfig = await loadPolicy(source, {
+      jsonOnly: options?.jsonOnly
+    });
+
+    // Check if this is a module policy (imperative plugin) with code-level hooks
+    if (isImperativePlugin(policyConfig)) {
+      // Module policies: wrap as trusted-code plugin
+      const { plugin: imperativePlugin, compiled } = wrapImperativePolicy(
+        policyConfig,
+        baseCriteria
+      );
+      plugins.push(imperativePlugin);
+      allDisabledIds.push(...compiled.disabledIds);
+      if (compiled.passRateThreshold !== undefined) {
+        passRateThreshold = compiled.passRateThreshold;
+      }
+    } else {
+      // Declarative JSON policies: compile to safe-declarative plugin
+      const compiled: CompilationResult = compilePolicyConfig(policyConfig, baseCriteria);
+      plugins.push(compiled.plugin);
+      allDisabledIds.push(...compiled.disabledIds);
+      if (compiled.passRateThreshold !== undefined) {
+        passRateThreshold = compiled.passRateThreshold;
+      }
+    }
+  }
+
+  return {
+    plugins,
+    options: {
+      disabledRuleIds: allDisabledIds.length > 0 ? new Set(allDisabledIds) : undefined
+    },
+    passRateThreshold
+  };
+}
+
+/**
+ * Detect if a PolicyConfig contains imperative code.
+ *
+ * Module-sourced policies may contain check functions (criteria.add/extras.add)
+ * which cannot exist in JSON policies. Any policy with add entries
+ * is treated as imperative; policies with only disable/override are
+ * purely declarative regardless of source format.
+ */
+function isImperativePlugin(config: PolicyConfig): boolean {
+  const hasAddedCriteria = Boolean(config.criteria?.add?.length);
+  const hasAddedExtras = Boolean(config.extras?.add?.length);
+  return hasAddedCriteria || hasAddedExtras;
+}
+
+/**
+ * Wrap a module-sourced PolicyConfig as a trusted-code plugin.
+ * Uses the compiler for the heavy lifting, then overrides the trust tier.
+ * Also propagates disabledIds and passRateThreshold from the module policy.
+ */
+function wrapImperativePolicy(
+  config: PolicyConfig,
+  baseCriteria: ReadonlyArray<ReadinessCriterion>
+): { plugin: PolicyPlugin; compiled: CompilationResult } {
+  const compiled = compilePolicyConfig(config, baseCriteria);
+  const plugin: PolicyPlugin = {
+    ...compiled.plugin,
+    meta: {
+      ...compiled.plugin.meta,
+      sourceType: "module",
+      trust: "trusted-code"
+    }
+  };
+  return { plugin, compiled };
+}

--- a/src/services/policy/shadow.ts
+++ b/src/services/policy/shadow.ts
@@ -1,0 +1,192 @@
+/**
+ * Phase H: Shadow mode and parity gating.
+ *
+ * Runs the new plugin engine alongside the legacy readiness system,
+ * compares outputs, and logs discrepancies. This lets us validate that
+ * the new engine produces equivalent results before switching the default.
+ *
+ * Key design decisions:
+ * - Legacy and new engine share the same `ReadinessContext` (no duplicate I/O).
+ * - Discrepancies are logged to `.primer-cache/shadow-mode.log`, not stderr.
+ * - The function returns the legacy result by default; callers opt into
+ *   the new engine via `useNewEngine: true`.
+ */
+import fs from "fs/promises";
+import path from "path";
+
+import { validateCachePath } from "../../utils/fs";
+import type { ReadinessReport, ReadinessCriterionResult } from "../readiness";
+
+import { engineReportToReadiness } from "./adapter";
+import type { EngineReport } from "./types";
+
+export type ShadowResult = {
+  /** The report that should be used by the caller. */
+  report: ReadinessReport;
+  /** Whether the new engine was used as the primary result source. */
+  usedNewEngine: boolean;
+  /** Discrepancies found between legacy and new engine outputs. */
+  discrepancies: ShadowDiscrepancy[];
+};
+
+export type ShadowDiscrepancy = {
+  criterionId: string;
+  field: string;
+  legacyValue: unknown;
+  newValue: unknown;
+};
+
+/**
+ * Compare a legacy ReadinessReport with a new-engine EngineReport and
+ * record discrepancies.
+ *
+ * @returns The chosen report and any discrepancies found.
+ */
+export function compareShadow(
+  legacyReport: ReadinessReport,
+  engineReport: EngineReport,
+  options: {
+    repoPath: string;
+    passRateThreshold?: number;
+    useNewEngine?: boolean;
+  }
+): ShadowResult {
+  const newReport = engineReportToReadiness(engineReport, {
+    repoPath: options.repoPath,
+    isMonorepo: legacyReport.isMonorepo,
+    apps: legacyReport.apps,
+    passRateThreshold: options.passRateThreshold
+  });
+
+  // Pre-filter legacy criteria to repo-scope only: the engine's built-in plugin only
+  // runs repo-scoped criteria, so area/app-scoped entries would produce false-positive
+  // "presence: missing" discrepancies on every comparison.
+  const legacyRepoCriteria = legacyReport.criteria.filter((c) => c.scope === "repo");
+  const discrepancies = diffCriteria(legacyRepoCriteria, newReport.criteria);
+
+  return {
+    report: options.useNewEngine ? newReport : legacyReport,
+    usedNewEngine: options.useNewEngine ?? false,
+    discrepancies
+  };
+}
+
+/**
+ * Append shadow-mode discrepancies to `.primer-cache/shadow-mode.log`.
+ */
+export async function writeShadowLog(
+  repoPath: string,
+  discrepancies: ShadowDiscrepancy[]
+): Promise<void> {
+  if (discrepancies.length === 0) return;
+
+  const lines = [
+    `Shadow mode comparison — ${new Date().toISOString()}`,
+    `Discrepancies: ${discrepancies.length}`,
+    "",
+    ...discrepancies.map(
+      (d) =>
+        `[${JSON.stringify(d.criterionId)}] ${d.field}: legacy=${JSON.stringify(d.legacyValue)} new=${JSON.stringify(d.newValue)}`
+    ),
+    ""
+  ];
+
+  const cacheDir = path.join(repoPath, ".primer-cache");
+  const logPath = validateCachePath(cacheDir, "shadow-mode.log");
+  await fs.mkdir(path.dirname(logPath), { recursive: true });
+  await fs.appendFile(logPath, lines.join("\n") + "\n");
+}
+
+/**
+ * Diff criteria between legacy and new engine outputs.
+ * Compares id, status, pillar, level, impact, effort, and scope fields.
+ */
+function diffCriteria(
+  legacy: ReadinessCriterionResult[],
+  newCriteria: ReadinessCriterionResult[]
+): ShadowDiscrepancy[] {
+  const discrepancies: ShadowDiscrepancy[] = [];
+  const newById = new Map(newCriteria.map((c) => [c.id, c]));
+
+  for (const legacyCriterion of legacy) {
+    const newCriterion = newById.get(legacyCriterion.id);
+    if (!newCriterion) {
+      discrepancies.push({
+        criterionId: legacyCriterion.id,
+        field: "presence",
+        legacyValue: "exists",
+        newValue: "missing"
+      });
+      continue;
+    }
+
+    if (legacyCriterion.status !== newCriterion.status) {
+      discrepancies.push({
+        criterionId: legacyCriterion.id,
+        field: "status",
+        legacyValue: legacyCriterion.status,
+        newValue: newCriterion.status
+      });
+    }
+
+    if (legacyCriterion.pillar !== newCriterion.pillar) {
+      discrepancies.push({
+        criterionId: legacyCriterion.id,
+        field: "pillar",
+        legacyValue: legacyCriterion.pillar,
+        newValue: newCriterion.pillar
+      });
+    }
+
+    if (legacyCriterion.level !== newCriterion.level) {
+      discrepancies.push({
+        criterionId: legacyCriterion.id,
+        field: "level",
+        legacyValue: legacyCriterion.level,
+        newValue: newCriterion.level
+      });
+    }
+
+    if (legacyCriterion.impact !== newCriterion.impact) {
+      discrepancies.push({
+        criterionId: legacyCriterion.id,
+        field: "impact",
+        legacyValue: legacyCriterion.impact,
+        newValue: newCriterion.impact
+      });
+    }
+
+    if (legacyCriterion.effort !== newCriterion.effort) {
+      discrepancies.push({
+        criterionId: legacyCriterion.id,
+        field: "effort",
+        legacyValue: legacyCriterion.effort,
+        newValue: newCriterion.effort
+      });
+    }
+
+    if (legacyCriterion.scope !== newCriterion.scope) {
+      discrepancies.push({
+        criterionId: legacyCriterion.id,
+        field: "scope",
+        legacyValue: legacyCriterion.scope,
+        newValue: newCriterion.scope
+      });
+    }
+  }
+
+  // Check for criteria in new engine not present in legacy
+  const legacyIds = new Set(legacy.map((c) => c.id));
+  for (const newCriterion of newCriteria) {
+    if (!legacyIds.has(newCriterion.id)) {
+      discrepancies.push({
+        criterionId: newCriterion.id,
+        field: "presence",
+        legacyValue: "missing",
+        newValue: "exists"
+      });
+    }
+  }
+
+  return discrepancies;
+}

--- a/src/services/policy/types.ts
+++ b/src/services/policy/types.ts
@@ -1,0 +1,343 @@
+// ─── Signal & Recommendation Types ───
+// Core types for the unified plugin policy system.
+// Both imperative hook plugins and declarative JSON policies compile to
+// the same runtime contract via these types.
+
+/** Classification of what a signal detects. */
+export type SignalKind = "file" | "setting" | "mcp-server" | "model-config" | "git" | "custom";
+
+/** Result status of a signal detection. */
+export type SignalStatus = "detected" | "not-detected" | "error";
+
+/** Tracks which plugin created or modified a signal/recommendation. */
+export type Provenance = {
+  addedBy: string;
+  modifiedBy?: string[];
+};
+
+/** A single detection emitted by a detector. */
+export type Signal = {
+  id: string;
+  kind: SignalKind;
+  status: SignalStatus;
+  label: string;
+  evidence?: string[];
+  reason?: string;
+  origin: Provenance;
+  metadata?: Record<string, unknown>;
+};
+
+/** Impact level for a recommendation. */
+export type RecommendationImpact = "critical" | "high" | "medium" | "low" | "info";
+
+/** An actionable recommendation derived from signals. */
+export type Recommendation = {
+  id: string;
+  signalId: string;
+  impact: RecommendationImpact;
+  message: string;
+  origin: Provenance;
+  supersedes?: string[];
+  metadata?: Record<string, unknown>;
+};
+
+/** A warning emitted during policy execution (non-fatal). */
+export type PolicyWarning = {
+  pluginName: string;
+  stage: PluginStage;
+  message: string;
+};
+
+// ─── Patch types for immutable hook returns ───
+
+export type SignalPatch = {
+  add?: Signal[];
+  remove?: string[];
+  modify?: Array<{ id: string; changes: Partial<Omit<Signal, "id" | "origin">> }>;
+};
+
+export type RecommendationPatch = {
+  add?: Recommendation[];
+  remove?: string[];
+  modify?: Array<{ id: string; changes: Partial<Omit<Recommendation, "id" | "origin">> }>;
+};
+
+// ─── Plugin lifecycle ───
+
+export type PluginStage =
+  | "detect"
+  | "afterDetect"
+  | "beforeRecommend"
+  | "recommend"
+  | "afterRecommend";
+
+/** Read-only context available to all plugin lifecycle stages. */
+export type PolicyContext = {
+  repoPath: string;
+  rootFiles: string[];
+  rootPackageJson?: Record<string, unknown>;
+  /** Shared key-value cache scoped to a single engine run. */
+  cache: Map<string, unknown>;
+};
+
+/** A detector emits signals about the state of a repository. */
+export type Detector = {
+  id: string;
+  kind: SignalKind;
+  detect: (ctx: PolicyContext) => Promise<Signal | Signal[]>;
+};
+
+/** A recommender emits actionable recommendations based on signals. */
+export type Recommender = {
+  id: string;
+  recommend: (
+    signals: ReadonlyArray<Signal>,
+    ctx: PolicyContext
+  ) => Promise<Recommendation | Recommendation[]>;
+};
+
+/** Trust tier determines what a plugin is allowed to do. */
+export type PluginTrust = "trusted-code" | "safe-declarative";
+
+/** Source type of the plugin. */
+export type PluginSourceType = "module" | "json" | "builtin";
+
+/** Metadata describing a plugin. */
+export type PluginMeta = {
+  name: string;
+  version?: string;
+  /** Semver range of engine versions this plugin is compatible with. */
+  engine?: string;
+  /** Capabilities this plugin implements (e.g. "detect", "recommend", "hook"). */
+  capabilities?: string[];
+  sourceType: PluginSourceType;
+  trust: PluginTrust;
+};
+
+/**
+ * The canonical plugin contract.
+ * Both imperative module plugins and compiled JSON policies implement this.
+ * All hook stages are optional — plugins only implement what they need.
+ */
+export type PolicyPlugin = {
+  meta: PluginMeta;
+
+  /** Detectors that emit signals about repository state. */
+  detectors?: Detector[];
+
+  /** Called after all detectors run. Returns a patch to mutate signals. */
+  afterDetect?: (
+    signals: ReadonlyArray<Signal>,
+    ctx: PolicyContext
+  ) => Promise<SignalPatch | undefined>;
+
+  /** Called before recommenders run. Returns a patch to mutate signals. */
+  beforeRecommend?: (
+    signals: ReadonlyArray<Signal>,
+    ctx: PolicyContext
+  ) => Promise<SignalPatch | undefined>;
+
+  /** Recommenders that emit actionable recommendations. */
+  recommenders?: Recommender[];
+
+  /** Called after all recommenders run. Returns a patch to mutate recommendations. */
+  afterRecommend?: (
+    recommendations: ReadonlyArray<Recommendation>,
+    signals: ReadonlyArray<Signal>,
+    ctx: PolicyContext
+  ) => Promise<RecommendationPatch | undefined>;
+
+  /** Per-plugin error handler. Return true to continue remaining detectors/recommenders for this plugin, false to abort them. Does not affect other plugins in the chain. Note: return value is ignored for hook stages (afterDetect, beforeRecommend, afterRecommend); only effective in detect/recommend loops. */
+  onError?: (error: Error, stage: PluginStage, ctx: PolicyContext) => boolean;
+};
+
+// ─── Engine output ───
+
+/** Grade label for a readiness score. */
+export type Grade = "A" | "B" | "C" | "D" | "F";
+
+/** Complete output from the plugin engine. */
+export type EngineReport = {
+  readonly signals: ReadonlyArray<Signal>;
+  readonly recommendations: ReadonlyArray<Recommendation>;
+  readonly policyWarnings: ReadonlyArray<PolicyWarning>;
+  readonly score: number;
+  readonly grade: Grade;
+  readonly pluginChain: ReadonlyArray<string>;
+};
+
+// ─── Scoring ───
+
+const IMPACT_WEIGHTS: Record<RecommendationImpact, number> = {
+  critical: 5,
+  high: 4,
+  medium: 3,
+  low: 2,
+  info: 0
+};
+
+/**
+ * Engine-level scoring reducer.
+ * Score = 1 - (weighted unresolved recommendations / max possible weight).
+ * Max weight per signal is "critical" (5) — a single critical recommendation
+ * against one signal will produce score 0. This is intentional: critical
+ * findings are designed to dominate the score.
+ */
+export function calculateScore(
+  signals: ReadonlyArray<Signal>,
+  recommendations: ReadonlyArray<Recommendation>
+): { score: number; grade: Grade } {
+  // Exclude not-detected (skipped/non-applicable) signals from scoring denominator.
+  // Including them would inflate maxWeight and artificially boost scores for repos
+  // with many non-applicable criteria.
+  const activeSignals = signals.filter((s) => s.status !== "not-detected");
+  if (activeSignals.length === 0) {
+    return { score: 1, grade: "A" };
+  }
+
+  const maxWeight = activeSignals.length * IMPACT_WEIGHTS.critical;
+
+  const deductions = recommendations.reduce((sum, rec) => sum + IMPACT_WEIGHTS[rec.impact], 0);
+
+  const score = Math.max(0, Math.min(1, 1 - deductions / maxWeight));
+  return { score, grade: scoreToGrade(score) };
+}
+
+function scoreToGrade(score: number): Grade {
+  if (score >= 0.9) return "A";
+  if (score >= 0.8) return "B";
+  if (score >= 0.7) return "C";
+  if (score >= 0.6) return "D";
+  return "F";
+}
+
+// ─── Patch application ───
+
+/** Apply a SignalPatch to a list of signals, recording provenance. */
+export function applySignalPatch(
+  signals: Signal[],
+  patch: SignalPatch,
+  pluginName: string
+): Signal[] {
+  let result = [...signals];
+
+  if (patch.remove?.length) {
+    const removeSet = new Set(patch.remove);
+    result = result.filter((s) => !removeSet.has(s.id));
+  }
+
+  if (patch.modify?.length) {
+    for (const mod of patch.modify) {
+      const idx = result.findIndex((s) => s.id === mod.id);
+      if (idx >= 0) {
+        const existing = result[idx];
+        const changes = { ...mod.changes };
+        // Deep-merge metadata to avoid wiping existing fields (e.g. checkStatus)
+        if (changes.metadata && existing.metadata) {
+          changes.metadata = { ...existing.metadata, ...changes.metadata };
+        }
+        result[idx] = {
+          ...existing,
+          ...changes,
+          origin: {
+            ...existing.origin,
+            modifiedBy: [...(existing.origin.modifiedBy ?? []), pluginName]
+          }
+        };
+      }
+    }
+  }
+
+  if (patch.add?.length) {
+    result.push(
+      ...patch.add.map((s) => ({
+        ...s,
+        evidence: s.evidence ? [...s.evidence] : undefined,
+        metadata: s.metadata ? { ...s.metadata } : undefined
+      }))
+    );
+  }
+
+  return result;
+}
+
+/** Apply a RecommendationPatch to a list of recommendations, recording provenance. */
+export function applyRecommendationPatch(
+  recommendations: Recommendation[],
+  patch: RecommendationPatch,
+  pluginName: string
+): Recommendation[] {
+  let result = [...recommendations];
+
+  if (patch.remove?.length) {
+    const removeSet = new Set(patch.remove);
+    result = result.filter((r) => !removeSet.has(r.id));
+  }
+
+  if (patch.modify?.length) {
+    for (const mod of patch.modify) {
+      const idx = result.findIndex((r) => r.id === mod.id);
+      if (idx >= 0) {
+        const existing = result[idx];
+        result[idx] = {
+          ...existing,
+          ...mod.changes,
+          origin: {
+            ...existing.origin,
+            modifiedBy: [...(existing.origin.modifiedBy ?? []), pluginName]
+          }
+        };
+      }
+    }
+  }
+
+  if (patch.add?.length) {
+    result.push(
+      ...patch.add.map((r) => ({
+        ...r,
+        supersedes: r.supersedes ? [...r.supersedes] : undefined,
+        metadata: r.metadata ? { ...r.metadata } : undefined
+      }))
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Resolve supersedes: remove recommendations that are superseded by others.
+ * Records provenance on the superseding recommendation.
+ * Circular supersedes chains result in all involved recommendations being dropped.
+ */
+export function resolveSupersedes(recommendations: Recommendation[]): Recommendation[] {
+  const supersededIds = new Set<string>();
+  const recIds = new Set(recommendations.map((r) => r.id));
+  for (const rec of recommendations) {
+    if (rec.supersedes?.length) {
+      for (const id of rec.supersedes) {
+        // Only supersede IDs that actually exist in the list
+        if (recIds.has(id)) {
+          supersededIds.add(id);
+        }
+      }
+    }
+  }
+  return recommendations
+    .filter((r) => !supersededIds.has(r.id))
+    .map((r) => {
+      if (!r.supersedes?.length) return r;
+      // Record which recommendations were actually superseded
+      const actuallySuperseded = r.supersedes.filter((id) => supersededIds.has(id));
+      if (actuallySuperseded.length === 0) return r;
+      return {
+        ...r,
+        origin: {
+          ...r.origin,
+          modifiedBy: [
+            ...(r.origin.modifiedBy ?? []),
+            ...actuallySuperseded.map((id) => `superseded:${id}`)
+          ]
+        }
+      };
+    });
+}

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -272,8 +272,10 @@ function isAllowedSystemAlias(originalPath: string, realPath: string): boolean {
 }
 
 /**
- * Validate that a constructed path stays within the expected root directory.
- * Prevents path traversal via malicious repo names or owner slugs.
+ * Validate that constructed path segments stay within the expected root directory.
+ * Prevents traversal in the relative segments (e.g. "../../../etc") but does NOT
+ * validate the cacheRoot itself — callers are responsible for ensuring cacheRoot
+ * is a trusted path before passing it here.
  */
 export function validateCachePath(cacheRoot: string, ...segments: string[]): string {
   const resolvedRoot = path.resolve(cacheRoot);


### PR DESCRIPTION
## Summary

Introduces a new plugin-based policy engine that runs alongside the existing readiness system in **shadow mode** for safe validation before becoming the default.

### New modules (`src/services/policy/`)

| Module | Purpose |
|--------|---------|
| `types.ts` | Signal, Recommendation, Grade, PolicyContext interfaces |
| `compiler.ts` | Compiles policy configs into executable plugin chains |
| `loader.ts` | Loads and validates plugin chains from policy sources |
| `engine.ts` | Executes plugins, computes scores and grades |
| `adapter.ts` | Bridges engine reports to legacy ReadinessReport format |
| `shadow.ts` | Shadow mode logging for comparison with legacy path |

### Changes to existing code

- **`readiness.ts`** — adds optional `shadow` mode and `engine` field on `ReadinessReport`; refactors `isConfigSourced` tracking for clarity
- **`utils/fs.ts`** — clarifies `validateCachePath` caller responsibilities in comment
- **`README.md`** — documents new `policy/` directory and links plugin authoring guide

### Key design decisions

- **Shadow mode**: The engine runs in parallel with the legacy path — no user-facing behavior changes until validated
- **Backward compatible**: The `engine` field on `ReadinessReport` is optional, so existing CLI and VS Code extension consumers are unaffected
- **Security**: Config-sourced policies remain restricted to JSON-only (no dynamic imports)
- **Error resilience**: Plugin errors are caught per-stage and recorded as warnings without halting the pipeline

### Testing

- 7 new test files with comprehensive coverage
- All 440 tests pass
- Plugin authoring documentation in `docs/plugins.md`